### PR TITLE
Fix py3 startup issues

### DIFF
--- a/awsshell/compat.py
+++ b/awsshell/compat.py
@@ -6,7 +6,9 @@ if PY3:
     from html.parser import HTMLParser
     text_type = str
     from io import StringIO
+    import dbm
 else:
     from HTMLParser import HTMLParser
     text_type = unicode
     from cStringIO import StringIO
+    import anydbm as dbm

--- a/awsshell/docs.py
+++ b/awsshell/docs.py
@@ -1,7 +1,7 @@
-import shelve
+from awsshell import compat
 
 def load_doc_index(filename):
-    return DocRetriever(shelve.open(filename, 'r'))
+    return DocRetriever(compat.dbm.open(filename, 'r'))
 
 
 class DocRetriever(object):
@@ -18,19 +18,21 @@ class DocRetriever(object):
         docs = self._doc_index.get(dot_cmd)
         if docs is None:
             return u''
+        docs = docs.decode('utf-8')
         index = docs.find('SYNOPSIS')
         if index > 0:
             docs = docs[:index]
-        return docs.decode('utf-8')
+        return docs
 
     def extract_param(self, dot_cmd, param_name):
         docs = self._doc_index.get(dot_cmd)
         if docs is None:
             return u''
+        docs = docs.decode('utf-8')
         index = docs.find('OPTIONS')
         param_start_index = docs.find(param_name, index)
         param_end_index = docs.find('  --', param_start_index)
-        return docs[param_start_index:param_end_index].decode('utf-8')
+        return docs[param_start_index:param_end_index]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #13.

I'm in the process of refactoring some of the internals, so I'm hoping this is one of the last PRs I send that does not have tests.  I have verified that everything works with python3:

```
$ python --version
Python 3.4.2
$ aws-shell
aws> dynamodb list-tables
{
    "TableNames": []
}
```
