### PR TITLE
Switch to sqlite3 backend for doc index

### DIFF
--- a/awsshell/__init__.py
+++ b/awsshell/__init__.py
@@ -45,17 +45,18 @@ def main():
         index_data = json.loads(index_str)
     doc_index_file = determine_doc_index_filename()
     from awsshell.makeindex import write_doc_index
-    doc_data, db = docs.load_lazy_doc_index(doc_index_file)
+    doc_data = docs.load_lazy_doc_index(doc_index_file)
     # There's room for improvement here.  If the docs didn't finish
     # generating, we regen the whole doc index.  Ideally we pick up
     # from where we left off.
     try:
+        db = docs.load_doc_db(doc_index_file)
         db['__complete__']
     except KeyError:
         print("Creating doc index in the background. "
               "It will be a few minutes before all documentation is "
               "available.")
-        t = threading.Thread(target=write_doc_index, args=(doc_index_file, db))
+        t = threading.Thread(target=write_doc_index, args=(doc_index_file,))
         t.daemon = True
         t.start()
     completer = shellcomplete.AWSShellCompleter(

--- a/awsshell/db.py
+++ b/awsshell/db.py
@@ -1,0 +1,43 @@
+import os
+import sqlite3
+
+
+class ConcurrentDBM(object):
+
+    @classmethod
+    def open(cls, filename, create=False):
+        if create and not os.path.isfile(filename):
+            return cls.create(filename)
+        else:
+            db = sqlite3.connect(filename)
+            return cls(db)
+
+    @classmethod
+    def create(cls, filename):
+        db = sqlite3.connect(filename)
+        with db:
+            db.execute(
+                'CREATE TABLE docindex (key TEXT PRIMARY KEY, value TEXT)')
+        return cls(db)
+
+    def __init__(self, db):
+        self._db = db
+
+    def __getitem__(self, key):
+        cursor = self._db.cursor()
+        cursor.execute(
+            'SELECT value FROM docindex WHERE key = :key', {'key': key})
+        result = cursor.fetchone()
+        if result is not None:
+            return result[0]
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        with self._db:
+            self._db.execute(
+                'INSERT OR REPLACE INTO docindex (key, value) '
+                'VALUES (:key, :value)',
+                {'key': key, 'value': value})
+
+    def close(self):
+        self._db.close()

--- a/awsshell/docs.py
+++ b/awsshell/docs.py
@@ -1,26 +1,17 @@
 import threading
 
 from awsshell import compat
+from awsshell import db
 
 
 def load_lazy_doc_index(filename):
-    db = ConcurrentDBM(
-        compat.dbm.open(filename, 'c'))
-    return DocRetriever(db), db
+    d = load_doc_db(filename)
+    return DocRetriever(d)
 
 
-class ConcurrentDBM(object):
-    def __init__(self, db):
-        self._db = db
-        self._lock = threading.Lock()
-
-    def __getitem__(self, key):
-        with self._lock:
-            return self._db[key]
-
-    def __setitem__(self, key, value):
-        with self._lock:
-            self._db[key] = value
+def load_doc_db(filename):
+    d = db.ConcurrentDBM.open(filename, create=True)
+    return d
 
 
 class DocRetriever(object):

--- a/awsshell/makeindex.py
+++ b/awsshell/makeindex.py
@@ -13,6 +13,7 @@ from awscli.argprocess import ParamShorthandDocGen
 from awsshell import determine_doc_index_filename
 from awsshell.utils import remove_html
 from awsshell import compat
+from awsshell import docs
 
 
 SHORTHAND_DOC = ParamShorthandDocGen()
@@ -78,7 +79,7 @@ def write_doc_index(output_filename=None, db=None):
     user_provided_db = True
     if db is None:
         user_provided_db = False
-        db = compat.dbm.open(output_filename, 'c')
+        db = docs.load_doc_db(output_filename)
     try:
         _index_docs(db, help_command)
         db['__complete__'] = 'true'

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -1,0 +1,58 @@
+from awsshell import db
+import pytest
+
+
+@pytest.fixture
+def shell_db(tmpdir):
+    filename = tmpdir.join('docs.db').strpath
+    d = db.ConcurrentDBM.create(filename)
+    return d
+
+
+def test_can_get_and_set_value(shell_db):
+    shell_db['foo'] = 'bar'
+    assert shell_db['foo'] == 'bar'
+
+
+def test_raise_key_error_when_no_key_exists(shell_db):
+    try:
+        shell_db['foo']
+    except KeyError as e:
+        assert 'foo' in str(e)
+    else:
+        raise AssertionError("Expected KeyError")
+
+
+def test_can_set_multiple_values(shell_db):
+    shell_db['foo'] = 'a'
+    shell_db['bar'] = 'b'
+    assert shell_db['foo'] == 'a'
+    assert shell_db['bar'] == 'b'
+
+
+def test_can_change_existing_value(shell_db):
+    shell_db['foo'] = 'first'
+    shell_db['foo'] = 'second'
+    assert shell_db['foo'] == 'second'
+
+
+def test_can_update_multiple_times(shell_db):
+    for i in range(100):
+        shell_db['foo'] = str(i)
+    assert shell_db['foo'] == '99'
+
+
+def test_can_handle_unicode(shell_db):
+    shell_db['foo'] = u'\u2713'
+    assert shell_db['foo'] == u'\u2713'
+
+
+def test_can_create_and_open_db(tmpdir):
+    filename = tmpdir.join('foo.db').strpath
+    d = db.ConcurrentDBM.create(filename)
+    d['foo'] = 'bar'
+    d.close()
+
+    # Should be able to reopen the database and look up 'foo'.
+    d = db.ConcurrentDBM.open(filename)
+    assert d['foo'] == 'bar'

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,0 +1,14 @@
+from awsshell import docs
+from awsshell import db
+
+
+def test_lazy_doc_factory(tmpdir):
+    filename = tmpdir.join('foo.db').strpath
+    doc_index = docs.load_lazy_doc_index(filename)
+    assert isinstance(doc_index, docs.DocRetriever)
+
+
+def test_load_doc_db(tmpdir):
+    filename = tmpdir.join("foo.db").strpath
+    d = docs.load_doc_db(filename)
+    assert isinstance(d, db.ConcurrentDBM)


### PR DESCRIPTION
Better cross platform support.  There was some
complexity in getting this to work, namely that
you can't share connection across different threads
(even if you use your own locking).  The sqlite3 python
lib raises an error.

See https://docs.python.org/2/library/sqlite3.html#multithreading
for more info.

This is also slightly slower than before because each `__setitem__` call happens in a sqlite transaction.  This is needed to ensure that the sqlite connection in the main thread (that runs the aws-shell loop) can actually see the doc index updates being added incrementally.
