### PR TITLE
Update gitignore with standard excludes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,42 @@
+*.py[co]
+*.DS_Store
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+var
+sdist
+develop-eggs
+.installed.cfg
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+.cache
+
+#Translations
+*.mo
+
+#Mr Developer
+.mr.developer.cfg
+
+# Emacs backup files
+*~
+
+# Eclipse IDE
+/.project
+/.pydevproject
+
+# IDEA IDE
+.idea*
+src/
+
+# Completions Index
 completions.idx


### PR DESCRIPTION
I used the [aws-cli .gitignore](https://github.com/aws/aws-cli/blob/develop/.gitignore) as a template.

Added `.cache`.

Might be a few other ignores to add from the [standard Python .gitignore](https://github.com/github/gitignore/blob/master/Python.gitignore) in the future (docs, etc).
