### PR TITLE
Change ctrl-c to do a keyboard interrupt vs app exit.

### DIFF
--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -260,7 +260,7 @@ class AWSShell(object):
             style=style_factory.style,
             buffers=buffers,
             buffer=self.create_buffer(completer, history),
-            on_abort=AbortAction.RAISE_EXCEPTION,
+            on_abort=AbortAction.RETRY,
             on_exit=AbortAction.RAISE_EXCEPTION,
             on_input_timeout=Callback(self.on_input_timeout),
             key_bindings_registry=self.key_manager.manager.registry,


### PR DESCRIPTION
It seems to be the more standard behavior to use ctrl-c to keyboard interrupt and ctrl-d to exit the app.  This behavior is consistent with the python interactive shell. 

Making this change allows users to quickly cancel out of the current command.  Users can still use ctrl-d or f10 to exit the app.
