### PR TITLE
Add cross platform temporary file creation

### DIFF
--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -5,7 +5,6 @@ Main entry point to the AWS Shell.
 """
 from __future__ import unicode_literals
 import os
-import tempfile
 import subprocess
 import logging
 import sys
@@ -26,7 +25,7 @@ from awsshell.config import Config
 from awsshell.keys import KeyManager
 from awsshell.style import StyleFactory
 from awsshell.toolbar import Toolbar
-from awsshell.utils import build_config_file_path
+from awsshell.utils import build_config_file_path, temporary_file
 from awsshell import compat
 
 
@@ -75,7 +74,7 @@ class EditHandler(object):
         all_commands = '\n'.join(
             ['aws ' + h for h in list(application.history)
              if not h.startswith(('.', '!'))])
-        with tempfile.NamedTemporaryFile('w') as f:
+        with temporary_file('w') as f:
             f.write(all_commands)
             f.flush()
             editor = self._get_editor_command()

--- a/awsshell/utils.py
+++ b/awsshell/utils.py
@@ -2,6 +2,10 @@
 from __future__ import print_function
 import os
 import awscli
+import contextlib
+import tempfile
+import uuid
+import shutil
 
 from awsshell.compat import HTMLParser
 
@@ -20,6 +24,25 @@ def remove_html(html):
 
 def build_config_file_path(file_name):
     return os.path.join(os.path.expanduser('~'), '.aws', 'shell', file_name)
+
+
+@contextlib.contextmanager
+def temporary_file(mode):
+    """Cross platform temporary file creation.
+
+    This is an alternative to ``tempfile.NamedTemporaryFile`` that
+    also works on windows and avoids the "file being used by
+    another process" error.
+    """
+    tempdir = tempfile.mkdtemp()
+    basename = 'tmpfile-%s' % (uuid.uuid4())
+    full_filename = os.path.join(tempdir, basename)
+    open(full_filename, 'w').close()
+    try:
+        with open(full_filename, mode) as f:
+            yield f
+    finally:
+        shutil.rmtree(tempdir)
 
 
 class DataOnly(HTMLParser):

--- a/awsshell/utils.py
+++ b/awsshell/utils.py
@@ -34,15 +34,18 @@ def temporary_file(mode):
     also works on windows and avoids the "file being used by
     another process" error.
     """
-    tempdir = tempfile.mkdtemp()
+    tempdir = tempfile.gettempdir()
     basename = 'tmpfile-%s' % (uuid.uuid4())
     full_filename = os.path.join(tempdir, basename)
-    open(full_filename, 'w').close()
+    if 'w' not in mode:
+        # We need to create the file before we can open
+        # it in 'r' mode.
+        open(full_filename, 'w').close()
     try:
         with open(full_filename, mode) as f:
             yield f
     finally:
-        shutil.rmtree(tempdir)
+        os.remove(f.name)
 
 
 class DataOnly(HTMLParser):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,6 +6,7 @@ import shutil
 from awsshell.utils import FSLayer
 from awsshell.utils import InMemoryFSLayer
 from awsshell.utils import FileReadError
+from awsshell.utils import temporary_file
 
 
 class TestFSLayer(unittest.TestCase):
@@ -64,3 +65,19 @@ class TestInMemoryFSLayer(unittest.TestCase):
     def test_file_does_not_exist_error(self):
         with self.assertRaises(FileReadError):
             self.fslayer.file_contents('/tmp/thisdoesnot-exist.asdf')
+
+
+class TestTemporaryFile(unittest.TestCase):
+    def test_can_use_as_context_manager(self):
+        with temporary_file('w') as f:
+            filename = f.name
+            f.write("foobar")
+            f.flush()
+            self.assertEqual(open(filename).read(), "foobar")
+
+    def test_is_removed_after_exiting_context(self):
+        with temporary_file('w') as f:
+            filename = f.name
+            f.write("foobar")
+            f.flush()
+        self.assertFalse(os.path.isfile(filename))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -81,3 +81,15 @@ class TestTemporaryFile(unittest.TestCase):
             f.write("foobar")
             f.flush()
         self.assertFalse(os.path.isfile(filename))
+
+    def test_can_open_in_read(self):
+        with temporary_file('r') as f:
+            filename = f.name
+            assert f.read() == ''
+            # Verify we can open the file again
+            # in another file descriptor.
+            with open(filename, 'w') as f2:
+                f2.write("foobar")
+            f.seek(0)
+            assert f.read() == "foobar"
+        self.assertFalse(os.path.isfile(filename))


### PR DESCRIPTION
Fixes #55 

`tempfile.NamedTemporaryFile` creates a file that cannot be opened twice on windows.  We had to make a similar change in the aws-cli a while back.