### PR TITLE
Fix tests if ~/.aws/shell/ doesn't exist.

### DIFF
--- a/awsshell/config.py
+++ b/awsshell/config.py
@@ -75,9 +75,17 @@ class Config(object):
         :type overwrite: bool
         :param overwrite: (Optional) Determines whether to overwrite the
             existing config file, if it exists.
+
+        :raises: :class:`OSError <exceptions.OSError>`
         """
         expanded_config_path = os.path.expanduser(config_path)
         if not overwrite and os.path.isfile(config_path):
             return
         else:
+            try:
+                config_path_dir_name = os.path.dirname(config_path)
+                os.makedirs(config_path_dir_name)
+            except OSError:
+                if not os.path.isdir(config_path_dir_name):
+                    raise
             shutil.copyfile(template_path, config_path)


### PR DESCRIPTION
Fixes issues with test_keys.py and test_config.py.  Creates the directory that will contain the awsshellrc config file if it doesn't yet exist.  Once it exists, continues with copying the template config file to ~/.aws/shell/awsshellrc.