### PR TITLE
Update aws-shell to work with prompt_toolkit==0.54.0

### DIFF
--- a/awsshell/style.py
+++ b/awsshell/style.py
@@ -15,6 +15,7 @@ from pygments.style import Style
 from pygments.util import ClassNotFound
 from pygments.styles import get_style_by_name
 from prompt_toolkit.styles import default_style_extensions
+from prompt_toolkit.styles import PygmentsStyle
 
 
 class StyleFactory(object):
@@ -70,4 +71,4 @@ class StyleFactory(object):
                 Token.Toolbar.Arg.Text: 'nobold'
             })
 
-        return CliStyle
+        return PygmentsStyle(CliStyle)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 requires = [
     'awscli>=1.8.9,<2.0.0',
-    'prompt-toolkit==0.52',
+    'prompt-toolkit==0.54',
     'boto3>=1.2.1',
     'configobj>=5.0.6',
 ]

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -52,9 +52,5 @@ class KeysTest(unittest.TestCase):
             assert show_help != self.aws_shell.show_help
 
     def test_F10(self):
-        # Exiting from the test in this mock test environment will throw:
-        #   IOError: [Errno 25] Inappropriate ioctl for device
-        # In a non-mock test environment it would through a EOFError.
-        # TODO: Probably better to mock the call to event.cli.set_exit().
-        with self.assertRaises(IOError) as e:
-            self.processor.feed_key(KeyPress(Keys.F10, ''))
+        self.processor.feed_key(KeyPress(Keys.F10, ''))
+        assert self.aws_shell.cli.is_exiting


### PR DESCRIPTION
I also needed to update one of the unit tests for the
F10 keypress.  On 0.54.0, an IOError is no longer being
raised so I'm just testing the is_exiting flag
directly.

Also did a bit of manual testing to ensure the UI looked correct.  All seems well.

Closes #60.

cc @donnemartin 