### PR TITLE
Ensure clean "make check" output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,9 @@ env:
 sudo: false
 install:
   - travis_retry pip install tox
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install -r requirements-dev.txt; fi
 script:
   - tox
+  # We only need to run the lint/flake8 checks on one version of python
+  # So I've arbitrarily chosen python2.7.
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then make check; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
 sudo: false
 install:
   - travis_retry pip install tox
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install -r requirements-dev.txt; fi
+  - if [[ $TOXENV == 'py27' ]]; then pip install -r requirements-dev.txt; pip install -e .; fi
 script:
   - tox
   # We only need to run the lint/flake8 checks on one version of python
   # So I've arbitrarily chosen python2.7.
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then make check; fi
+  - if [[ $TOXENV == 'py27' ]]; then make check; fi

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,25 @@ check:
 	#
 	#
 	#
-	###### PYLINT ######
-	# Python linter.
-	#
-	#
-	#
-	pylint --rcfile .pylintrc awsshell
-	#
-	#
-	#
 	# Proper docstring conventions according to pep257
 	#
 	#
-	pep257 --add-ignore=D100,D101,D102,D103,D104,D105
+	pep257 --add-ignore=D100,D101,D102,D103,D104,D105,D204
+	#
+	#
+	#
+	###### PYLINT ERRORS ONLY ######
+	#
+	#
+	#
+	pylint --rcfile .pylintrc -E awsshell
 
+pylint:
+	###### PYLINT ######
+	# Python linter.  This will generally not have clean output.
+	# So you'll need to manually verify this output.
+	#
+	#
+	pylint --rcfile .pylintrc awsshell
 coverage:
 	py.test --cov awsshell --cov-report term-missing tests/

--- a/awsshell/__init__.py
+++ b/awsshell/__init__.py
@@ -48,8 +48,7 @@ def main():
     # generating, we regen the whole doc index.  Ideally we pick up
     # from where we left off.
     try:
-        db = docs.load_doc_db(doc_index_file)
-        db['__complete__']
+        docs.load_doc_db(doc_index_file)['__complete__']
     except KeyError:
         print("Creating doc index in the background. "
               "It will be a few minutes before all documentation is "

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -158,7 +158,17 @@ class AWSShell(object):
         self._docs = docs
         self.current_docs = u''
         self.refresh_cli = False
+        self.key_manager = None
         self._dot_cmd = DotCommandHandler()
+
+        # These attrs come from the config file.
+        self.config_obj = None
+        self.config_section = None
+        self.enable_vi_bindings = None
+        self.show_completion_columns = None
+        self.show_help = None
+        self.theme = None
+
         self.load_config()
 
     def load_config(self):

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -15,7 +15,6 @@ from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.filters import Always
 from prompt_toolkit.interface import CommandLineInterface, Application
 from prompt_toolkit.interface import AbortAction, AcceptAction
-from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.utils import Callback
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.history import InMemoryHistory, FileHistory

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -40,6 +40,7 @@ class InputInterrupt(Exception):
 
     Raising `InputInterrupt` is useful to force a cli rebuild, which is
     sometimes necessary in order for config changes to take effect.
+
     """
     pass
 
@@ -91,7 +92,7 @@ class DotCommandHandler(object):
         self._err = err
 
     def handle_cmd(self, command, application):
-        """Handles running a given dot command from a user.
+        """Handle running a given dot command from a user.
 
         :type command: str
         :param command: The full dot command string, e.g. ``.edit``,
@@ -115,7 +116,7 @@ class DotCommandHandler(object):
 
 
 class AWSShell(object):
-    """Encapsulates the ui, completer, command history, docs, and config.
+    """Encapsulate the ui, completer, command history, docs, and config.
 
     Runs the input event loop and delegates the command execution to either
     the `awscli` or the underlying shell.
@@ -147,6 +148,7 @@ class AWSShell(object):
 
     :type theme: str
     :param theme: The pygments theme.
+
     """
 
     def __init__(self, completer, model_completer, docs):
@@ -172,7 +174,7 @@ class AWSShell(object):
         self.load_config()
 
     def load_config(self):
-        """Loads the config from the config file or template."""
+        """Load the config from the config file or template."""
         config = Config()
         self.config_obj = config.load('awsshellrc')
         self.config_section = self.config_obj['aws-shell']
@@ -186,7 +188,7 @@ class AWSShell(object):
         self.theme = self.config_section['theme']
 
     def save_config(self):
-        """Saves the config to the config file."""
+        """Save the config to the config file."""
         self.config_section['match_fuzzy'] = self.model_completer.match_fuzzy
         self.config_section['enable_vi_bindings'] = self.enable_vi_bindings
         self.config_section['show_completion_columns'] = \
@@ -235,13 +237,14 @@ class AWSShell(object):
                     p.communicate()
 
     def stop_input_and_refresh_cli(self):
-        """Stops input by raising an `InputInterrupt`, forces a cli refresh.
+        """Stop input by raising an `InputInterrupt`, forces a cli refresh.
 
         The cli refresh is necessary because changing options such as key
         bindings, single vs multi column menu completions, and the help pane
         all require a rebuild.
 
         :raises: :class:`InputInterrupt <exceptions.InputInterrupt>`.
+
         """
         self.refresh_cli = True
         self.cli.request_redraw()
@@ -267,7 +270,7 @@ class AWSShell(object):
             accept_action=AcceptAction.RETURN_DOCUMENT)
 
     def create_key_manager(self):
-        """Creates the :class:`KeyManager`.
+        """Create the :class:`KeyManager`.
 
         The inputs to KeyManager are expected to be callable, so we can't
         use the standard @property and @attrib.setter for these attributes.
@@ -277,13 +280,14 @@ class AWSShell(object):
         :return: A KeyManager with callables to set the toolbar options.  Also
             includes the method stop_input_and_refresh_cli to ensure certain
             options take effect within the current session.
-        """
 
+        """
         def set_match_fuzzy(match_fuzzy):
             """Setter for fuzzy matching mode.
 
             :type match_fuzzy: bool
             :param match_fuzzy: The match fuzzy flag.
+
             """
             self.model_completer.match_fuzzy = match_fuzzy
 
@@ -295,6 +299,7 @@ class AWSShell(object):
 
             :type enable_vi_bindings: bool
             :param enable_vi_bindings: The enable Vi bindings flag.
+
             """
             self.enable_vi_bindings = enable_vi_bindings
 
@@ -304,6 +309,7 @@ class AWSShell(object):
             :type show_completion_columns: bool
             :param show_completion_columns: The show completions in
                 multiple columns flag.
+
             """
             self.show_completion_columns = show_completion_columns
 
@@ -312,6 +318,7 @@ class AWSShell(object):
 
             :type show_help: bool
             :param show_help: The show help flag.
+
             """
             self.show_help = show_help
 

--- a/awsshell/config.py
+++ b/awsshell/config.py
@@ -39,7 +39,8 @@ class Config(object):
         if config_file is None:
             config_file = config_template
         config_path = build_config_file_path(config_file)
-        template_path = os.path.join(os.path.dirname(__file__), config_template)
+        template_path = os.path.join(os.path.dirname(__file__),
+                                     config_template)
         self._copy_template_to_config(template_path, config_path)
         return self._load_template_or_config(template_path, config_path)
 
@@ -78,7 +79,7 @@ class Config(object):
 
         :raises: :class:`OSError <exceptions.OSError>`
         """
-        expanded_config_path = os.path.expanduser(config_path)
+        config_path = os.path.expanduser(config_path)
         if not overwrite and os.path.isfile(config_path):
             return
         else:

--- a/awsshell/config.py
+++ b/awsshell/config.py
@@ -22,7 +22,7 @@ class Config(object):
     """Reads and writes the config template and user config file."""
 
     def load(self, config_template, config_file=None):
-        """Reads the config file if it exists, else reads the default config.
+        """Read the config file if it exists, else read the default config.
 
         Creates the user config file if it doesn't exist using the template.
 
@@ -45,7 +45,7 @@ class Config(object):
         return self._load_template_or_config(template_path, config_path)
 
     def _load_template_or_config(self, template_path, config_path):
-        """Loads the config file if it exists, else reads the default config.
+        """Load the config file if it exists, else read the default config.
 
         :type template_path: str
         :param template_path: The template config file path.
@@ -65,7 +65,7 @@ class Config(object):
 
     def _copy_template_to_config(self, template_path,
                                  config_path, overwrite=False):
-        """Writes the default config from a template.
+        """Write the default config from a template.
 
         :type template_path: str
         :param template_path: The template config file path.

--- a/awsshell/docs.py
+++ b/awsshell/docs.py
@@ -13,8 +13,7 @@ def load_doc_db(filename):
 
 
 class DocRetriever(object):
-    """Retrieves documentation for the AWS CLI.
-    """
+    """Retrieve documentation for the AWS CLI."""
     def __init__(self, doc_index):
         # Internally, most of the speedup comes from
         # the fact that this data is pre-rendered and

--- a/awsshell/index/completion.py
+++ b/awsshell/index/completion.py
@@ -70,7 +70,7 @@ class CompletionIndex(object):
             self._cache_dir, 'completions-%s.json' % version_string)
 
     def load_completions(self):
-        """Loads completions from the completion index.
+        """Load completions from the completion index.
 
         Updates the following attributes:
             * commands

--- a/awsshell/keys.py
+++ b/awsshell/keys.py
@@ -44,7 +44,7 @@ class KeyManager(object):
                             set_show_completion_columns,
                             get_show_help, set_show_help,
                             stop_input_and_refresh_cli):
-        """Creates and initializes the keybinding manager.
+        """Create and initialize the keybinding manager.
 
         :type get_fuzzy_match: callable
         :param get_fuzzy_match: Gets the fuzzy matching config.
@@ -81,6 +81,7 @@ class KeyManager(object):
 
         :rtype: :class:`prompt_toolkit.KeyBindingManager`
         :return: A custom `KeyBindingManager`.
+
         """
         assert callable(get_match_fuzzy)
         assert callable(set_match_fuzzy)
@@ -101,51 +102,56 @@ class KeyManager(object):
 
         @self.manager.registry.add_binding(Keys.F2)
         def handle_f2(_):
-            """Enables/disables fuzzy matching.
+            """Toggle fuzzy matching.
 
             :type _: :class:`prompt_toolkit.Event`
             :param _: (Unused)
+
             """
             set_match_fuzzy(not get_match_fuzzy())
 
         @self.manager.registry.add_binding(Keys.F3)
         def handle_f3(_):
-            """Enables/disables Vi mode keybindings matching.
+            """Toggle Vi mode keybindings matching.
 
             Disabling Vi keybindings will enable Emacs keybindings.
 
             :type _: :class:`prompt_toolkit.Event`
             :param _: (Unused)
+
             """
             set_enable_vi_bindings(not get_enable_vi_bindings())
             stop_input_and_refresh_cli()
 
         @self.manager.registry.add_binding(Keys.F4)
         def handle_f4(_):
-            """Enables/disables multiple column completions.
+            """Toggle multiple column completions.
 
             :type _: :class:`prompt_toolkit.Event`
             :param _: (Unused)
+
             """
             set_show_completion_columns(not get_show_completion_columns())
             stop_input_and_refresh_cli()
 
         @self.manager.registry.add_binding(Keys.F5)
         def handle_f5(_):
-            """Shows/hides the help container.
+            """Toggle the help container.
 
             :type _: :class:`prompt_toolkit.Event`
             :param _: (Unused)
+
             """
             set_show_help(not get_show_help())
             stop_input_and_refresh_cli()
 
         @self.manager.registry.add_binding(Keys.F10)
         def handle_f10(event):
-            """Quits when the `F10` key is pressed.
+            """Quit when the `F10` key is pressed.
 
             :type event: :class:`prompt_toolkit.Event`
             :param event: Contains info about the event, namely the cli
                 which is used for exiting the app.
+
             """
             event.cli.set_exit()

--- a/awsshell/keys.py
+++ b/awsshell/keys.py
@@ -27,11 +27,10 @@ class KeyManager(object):
     :param manager: A custom `KeyBindingManager`.
     """
 
-    def __init__(
-        self, get_match_fuzzy, set_match_fuzzy,
-        get_enable_vi_bindings, set_enable_vi_bindings,
-        get_show_completion_columns, set_show_completion_columns,
-        get_show_help, set_show_help, stop_input_and_refresh_cli):
+    def __init__(self, get_match_fuzzy, set_match_fuzzy,
+                 get_enable_vi_bindings, set_enable_vi_bindings,
+                 get_show_completion_columns, set_show_completion_columns,
+                 get_show_help, set_show_help, stop_input_and_refresh_cli):
         self.manager = None
         self._create_key_manager(
             get_match_fuzzy, set_match_fuzzy,
@@ -39,11 +38,12 @@ class KeyManager(object):
             get_show_completion_columns, set_show_completion_columns,
             get_show_help, set_show_help, stop_input_and_refresh_cli)
 
-    def _create_key_manager(
-        self, get_match_fuzzy, set_match_fuzzy,
-        get_enable_vi_bindings, set_enable_vi_bindings,
-        get_show_completion_columns, set_show_completion_columns,
-        get_show_help, set_show_help, stop_input_and_refresh_cli):
+    def _create_key_manager(self, get_match_fuzzy, set_match_fuzzy,
+                            get_enable_vi_bindings, set_enable_vi_bindings,
+                            get_show_completion_columns,
+                            set_show_completion_columns,
+                            get_show_help, set_show_help,
+                            stop_input_and_refresh_cli):
         """Creates and initializes the keybinding manager.
 
         :type get_fuzzy_match: callable

--- a/awsshell/lexer.py
+++ b/awsshell/lexer.py
@@ -10,9 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import ast
-import os
-
 from pygments.lexer import RegexLexer
 from pygments.lexer import words
 from pygments.token import Keyword, Literal, Name, Operator, Text

--- a/awsshell/loaders.py
+++ b/awsshell/loaders.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 from awsshell.utils import build_config_file_path
 

--- a/awsshell/makeindex.py
+++ b/awsshell/makeindex.py
@@ -122,7 +122,7 @@ def render_docs_for_cmd(help_command):
 
 
 def convert_rst_to_basic_text(contents):
-    """Converts restructured text to basic text output.
+    """Convert restructured text to basic text output.
 
     This function removes most of the decorations added
     in restructured text.

--- a/awsshell/resource/index.py
+++ b/awsshell/resource/index.py
@@ -92,7 +92,7 @@ class CompleterQuery(object):
         self._index = resource_index
 
     def describe_autocomplete(self, service, operation, param):
-        """
+        """Describe operation and args needed for server side completion.
 
         :type service: str
         :param service: The AWS service name.

--- a/awsshell/style.py
+++ b/awsshell/style.py
@@ -53,21 +53,22 @@ class StyleFactory(object):
             styles = {}
             styles.update(style.styles)
             styles.update(default_style_extensions)
+            t = Token
             styles.update({
-                Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
-                Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
-                Token.Menu.Completions.Meta.Current: 'bg:#00aaaa #000000',
-                Token.Menu.Completions.Meta: 'bg:#00aaaa #ffffff',
-                Token.Menu.Completions.ProgressButton: 'bg:#003333',
-                Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
-                Token.Toolbar: 'bg:#222222 #cccccc',
-                Token.Toolbar.Off: 'bg:#222222 #696969',
-                Token.Toolbar.On: 'bg:#222222 #ffffff',
-                Token.Toolbar.Search: 'noinherit bold',
-                Token.Toolbar.Search.Text: 'nobold',
-                Token.Toolbar.System: 'noinherit bold',
-                Token.Toolbar.Arg: 'noinherit bold',
-                Token.Toolbar.Arg.Text: 'nobold'
+                t.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
+                t.Menu.Completions.Completion: 'bg:#008888 #ffffff',
+                t.Menu.Completions.Meta.Current: 'bg:#00aaaa #000000',
+                t.Menu.Completions.Meta: 'bg:#00aaaa #ffffff',
+                t.Menu.Completions.ProgressButton: 'bg:#003333',
+                t.Menu.Completions.ProgressBar: 'bg:#00aaaa',
+                t.Toolbar: 'bg:#222222 #cccccc',
+                t.Toolbar.Off: 'bg:#222222 #696969',
+                t.Toolbar.On: 'bg:#222222 #ffffff',
+                t.Toolbar.Search: 'noinherit bold',
+                t.Toolbar.Search.Text: 'nobold',
+                t.Toolbar.System: 'noinherit bold',
+                t.Toolbar.Arg: 'noinherit bold',
+                t.Toolbar.Arg.Text: 'nobold'
             })
 
         return CliStyle

--- a/awsshell/style.py
+++ b/awsshell/style.py
@@ -18,7 +18,7 @@ from prompt_toolkit.styles import default_style_extensions
 
 
 class StyleFactory(object):
-    """Provides styles for the autocomplete menu and the toolbar.
+    """Provide styles for the autocomplete menu and the toolbar.
 
     :type style: :class:`pygments.style.StyleMeta`
     :param style: Contains pygments style info.
@@ -28,7 +28,7 @@ class StyleFactory(object):
         self.style = self.style_factory(style_name)
 
     def style_factory(self, style_name):
-        """Retrieves the specified pygments style.
+        """Retrieve the specified pygments style.
 
         If the specified style is not found, the vim style is returned.
 

--- a/awsshell/substring.py
+++ b/awsshell/substring.py
@@ -13,7 +13,7 @@
 
 
 def substring_search(word, collection):
-    """Finds all matches in the `collection` for the specified `word`.
+    """Find all matches in the `collection` for the specified `word`.
 
     If `word` is empty, returns all items in `collection`.
 

--- a/awsshell/substring.py
+++ b/awsshell/substring.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+
 def substring_search(word, collection):
     """Finds all matches in the `collection` for the specified `word`.
 

--- a/awsshell/toolbar.py
+++ b/awsshell/toolbar.py
@@ -14,10 +14,11 @@ from pygments.token import Token
 
 
 class Toolbar(object):
-    """Shows information about the aws-shell in a tool bar.
+    """Show information about the aws-shell in a tool bar.
 
     :type handler: callable
     :param handler: Wraps the callable `get_toolbar_items`.
+
     """
 
     def __init__(self, get_match_fuzzy, get_enable_vi_bindings,
@@ -28,7 +29,7 @@ class Toolbar(object):
 
     def _create_toolbar_handler(self, get_match_fuzzy, get_enable_vi_bindings,
                                 get_show_completion_columns, get_show_help):
-        """Creates the toolbar handler.
+        """Create the toolbar handler.
 
         :type get_fuzzy_match: callable
         :param fuzzy_match: Gets the fuzzy matching config.
@@ -46,6 +47,7 @@ class Toolbar(object):
 
         :rtype: callable
         :returns: get_toolbar_items.
+
         """
         assert callable(get_match_fuzzy)
         assert callable(get_enable_vi_bindings)
@@ -53,7 +55,7 @@ class Toolbar(object):
         assert callable(get_show_help)
 
         def get_toolbar_items(_):
-            """Returns the toolbar items.
+            """Return the toolbar items.
 
             :type _: :class:`prompt_toolkit.Cli`
             :param _: (Unused)

--- a/awsshell/toolbar.py
+++ b/awsshell/toolbar.py
@@ -87,15 +87,15 @@ class Toolbar(object):
                 show_help_cfg = 'OFF'
             return [
                 (match_fuzzy_token,
-                    ' [F2] Fuzzy: {0} '.format(match_fuzzy_cfg)),
+                 ' [F2] Fuzzy: {0} '.format(match_fuzzy_cfg)),
                 (enable_vi_bindings_token,
-                    ' [F3] Keys: {0} '.format(enable_vi_bindings_cfg)),
+                 ' [F3] Keys: {0} '.format(enable_vi_bindings_cfg)),
                 (show_columns_token,
-                    ' [F4] {0} Column '.format(show_columns_cfg)),
+                 ' [F4] {0} Column '.format(show_columns_cfg)),
                 (show_help_token,
-                    ' [F5] Help: {0} '.format(show_help_cfg)),
+                 ' [F5] Help: {0} '.format(show_help_cfg)),
                 (Token.Toolbar,
-                    ' [F10] Exit ')
+                 ' [F10] Exit ')
             ]
 
         return get_toolbar_items

--- a/awsshell/ui.py
+++ b/awsshell/ui.py
@@ -34,6 +34,7 @@ def create_default_layout(app, message='',
                           extra_input_processors=None, multiline=False):
     """
     Generate default layout.
+
     Returns a ``Layout`` instance.
 
     :param message: Text to be used as prompt.
@@ -193,10 +194,12 @@ def create_default_layout(app, message='',
 
 
 def _split_multiline_prompt(get_prompt_tokens):
-    """
+    """Split prompt tokens into two multiline prompt token functions.
+
     Take a `get_prompt_tokens` function. and return two new functions instead.
     One that returns the tokens to be shown on the lines above the input, and
     another one with the tokens to be shown at the first line of the input.
+
     """
     def before(cli):
         result = []

--- a/awsshell/ui.py
+++ b/awsshell/ui.py
@@ -75,7 +75,8 @@ def create_default_layout(app, message='',
     try:
         if issubclass(lexer, Lexer):
             lexer = PygmentsLexer(lexer)
-    except TypeError: # Happens when lexer is `None` or an instance of something else.
+    except TypeError:
+        # Happens when lexer is `None` or an instance of something else.
         pass
 
     # Create processors list.

--- a/awsshell/utils.py
+++ b/awsshell/utils.py
@@ -71,7 +71,7 @@ class FSLayer(object):
 
     """
     def file_contents(self, filename, binary=False):
-        """Returns the file for a given filename.
+        """Return the file for a given filename.
 
         If you want binary content use ``mode='rb'``.
 
@@ -87,7 +87,7 @@ class FSLayer(object):
             raise FileReadError(str(e))
 
     def file_exists(self, filename):
-        """Checks if a file exists.
+        """Check if a file exists.
 
         This method returns true if:
 

--- a/awsshell/utils.py
+++ b/awsshell/utils.py
@@ -5,7 +5,6 @@ import awscli
 import contextlib
 import tempfile
 import uuid
-import shutil
 
 from awsshell.compat import HTMLParser
 

--- a/awsshell/utils.py
+++ b/awsshell/utils.py
@@ -1,12 +1,14 @@
 """Utility module for misc aws shell functions."""
 from __future__ import print_function
 import os
-import awscli
 import contextlib
 import tempfile
 import uuid
 
+import awscli
+
 from awsshell.compat import HTMLParser
+
 
 AWSCLI_VERSION = awscli.__version__
 


### PR DESCRIPTION
Before fixing issues or adding feature requests, let's set up `make check` to run cleanly.  I've made a few changes:

1. Change the pylint run to just use `pylint -E`.  Even with a custom pylintrc there's too many false positives.  I'm also not a fan of cluttering code with pylint exclusion comments.
2. Add a `make pylint` that we can occasionally run and manually sift through any issues.
3. Add `make check` as part of the travis builds.
4. Small code cleanup to get `make check` to run cleanly.

The upcoming pull requests will use this as a base branch.