### PR TITLE
Add profile support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,6 +245,21 @@ variable before defaulting to ``notepad`` on Windows and
     aws> dynamodb list-tables
     aws> .edit
 
+Changing Profiles with .profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can change the current AWS CLI profile used by the aws-shell
+by using the ``.profile`` dot command.  If you run the ``.profile``
+command with no arguments, the currently configured shell profile
+will be printed.
+
+::
+
+    aws> .profile demo
+    Current shell profile changed to: demo
+    aws> .profile
+    Current shell profile: demo
+
 
 Executing Shell Commands
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,33 @@ you can try::
     TABLENAMES     Second
     TABLENAMES     Third
 
+Profiles
+--------
+
+The aws-shell supports AWS CLI profiles.  You have two options to use
+profiles.  First, you can provide a profile when you start the aws-shell::
+
+    $ aws-shell --profile prod
+    aws>
+
+When you do this all the server side completion as well as CLI commands
+you run will automatically use the ``prod`` profile.
+
+You can also change the current profile while you're in the aws-shell::
+
+    $ aws-shell
+    aws> .profile demo
+    Current shell profile changed to: demo
+
+You can also check what profile you've configured in the aws-shell using::
+
+    aws> .profile
+    Current shell profile: demo
+
+After changing your profile using the ``.profile`` dot command, all
+server side completion as well as CLI commands will automatically use
+the new profile you've configured.
+
 
 Features
 ========

--- a/awsshell/__init__.py
+++ b/awsshell/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, print_function
 
 import json
+import argparse
 import threading
 
 from awsshell import shellcomplete
@@ -28,6 +29,11 @@ def load_index(filename):
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--profile', help='The profile name to use '
+                        'when starting the AWS Shell.')
+    args = parser.parse_args()
+
     indexer = completion.CompletionIndex()
     try:
         index_str = indexer.load_index(utils.AWSCLI_VERSION)
@@ -59,6 +65,8 @@ def main():
     model_completer = autocomplete.AWSCLIModelCompleter(index_data)
     completer = shellcomplete.AWSShellCompleter(model_completer)
     shell = app.create_aws_shell(completer, model_completer, doc_data)
+    if args.profile:
+        shell.on_profile_change(args.profile)
     shell.run()
 
 

--- a/awsshell/__init__.py
+++ b/awsshell/__init__.py
@@ -66,7 +66,7 @@ def main():
     completer = shellcomplete.AWSShellCompleter(model_completer)
     shell = app.create_aws_shell(completer, model_completer, doc_data)
     if args.profile:
-        shell.on_profile_change(args.profile)
+        shell.profile = args.profile
     shell.run()
 
 

--- a/awsshell/shellcomplete.py
+++ b/awsshell/shellcomplete.py
@@ -11,7 +11,10 @@ logic, see awsshell.autocomplete.
 """
 import os
 import logging
+
+import botocore.session
 from prompt_toolkit.completion import Completer, Completion
+
 from awsshell import fuzzy
 
 
@@ -33,7 +36,6 @@ class AWSShellCompleter(Completer):
         self._server_side_completer = server_side_completer
 
     def _create_server_side_completer(self, session=None):
-        import botocore.session
         from awsshell.resource import index
         if session is None:
             session = botocore.session.Session()
@@ -47,6 +49,11 @@ class AWSShellCompleter(Completer):
         describer = index.CompleterDescriberCreator(loader)
         completer = index.ServerSideCompleter(client_creator, describer)
         return completer
+
+    def change_profile(self, profile_name):
+        """Change the profile used for server side completions."""
+        self._server_side_completer = self._create_server_side_completer(
+            session=botocore.session.Session(profile=profile_name))
 
     @property
     def completer(self):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -39,6 +39,48 @@ def test_edit_handler():
     assert command_run[0] == 'my-editor'
 
 
+def test_profile_handler_prints_profile():
+    shell = mock.Mock(spec=app.AWSShell)
+    shell.profile = 'myprofile'
+    stdout = compat.StringIO()
+    handler = app.ProfileHandler(stdout)
+    handler.run(['.profile'], shell)
+    assert stdout.getvalue().strip() == 'Current shell profile: myprofile'
+
+
+def test_profile_handler_when_no_profile_configured():
+    shell = mock.Mock(spec=app.AWSShell)
+    shell.profile = None
+    stdout = compat.StringIO()
+    handler = app.ProfileHandler(stdout)
+    handler.run(['.profile'], shell)
+    assert stdout.getvalue() == (
+        'Current shell profile: no profile configured\n'
+        'You can change profiles using: .profile profile-name\n'
+    )
+
+
+def test_profile_command_changes_profile():
+    shell = mock.Mock(spec=app.AWSShell)
+    shell.profile = 'myprofile'
+    stdout = compat.StringIO()
+    handler = app.ProfileHandler(stdout)
+
+    handler.run(['.profile', 'newprofile'], shell)
+
+    assert shell.profile == 'newprofile'
+
+
+def test_profile_prints_error_on_bad_syntax():
+    stderr = compat.StringIO()
+    handler = app.ProfileHandler(None, stderr)
+    handler.run(['.profile', 'a', 'b', 'c'], None)
+
+    # We don't really care about the exact usage message here,
+    # we just want to ensure usage was written to stderr.
+    assert 'Usage' in stderr.getvalue()
+
+
 def test_prints_error_message_on_unknown_dot_command(errstream):
     handler = app.DotCommandHandler(err=errstream)
     handler.handle_cmd(".unknown foo bar", None)
@@ -48,5 +90,6 @@ def test_prints_error_message_on_unknown_dot_command(errstream):
 def test_delegates_to_complete_changing_profile():
     completer = mock.Mock(spec=shellcomplete.AWSShellCompleter)
     shell = app.AWSShell(completer, mock.Mock(), mock.Mock())
-    shell.on_profile_change('mynewprofile')
+    shell.profile = 'mynewprofile'
     assert completer.change_profile.call_args == mock.call('mynewprofile')
+    assert shell.profile == 'mynewprofile'

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -3,6 +3,7 @@ import mock
 
 
 from awsshell import app
+from awsshell import shellcomplete
 from awsshell import compat
 
 
@@ -42,3 +43,10 @@ def test_prints_error_message_on_unknown_dot_command(errstream):
     handler = app.DotCommandHandler(err=errstream)
     handler.handle_cmd(".unknown foo bar", None)
     assert errstream.getvalue() == "Unknown dot command: .unknown\n"
+
+
+def test_delegates_to_complete_changing_profile():
+    completer = mock.Mock(spec=shellcomplete.AWSShellCompleter)
+    shell = app.AWSShell(completer, mock.Mock(), mock.Mock())
+    shell.on_profile_change('mynewprofile')
+    assert completer.change_profile.call_args == mock.call('mynewprofile')


### PR DESCRIPTION
This PR adds profile support:

* Add a `--profile` argument to start the AWS Shell with a specific profile (#89)
* Add a `.profile` dot command to query and change the current profile (#9)

Using the new argument:

```
$ aws-shell --profile prod
```

Using the dot command:

```
$ aws-shell
aws> .profile
Current shell profile: no profile configured
You can change profiles using: .profile profile-name
aws> .profile demo
Current shell profile changed to: demo
aws> .profile
Current shell profile: demo
aws> s3api list-buckets       # <---- will use the "demo" profile.  Also server side completion will use the "demo" profile
```

Because this is using the updated internal APIs from the server side completion fix, this PR is using `server-side-fix` as the base branch to make it easier to review.