### PR TITLE
Lock deps to major versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import setup, find_packages
 requires = [
     'awscli>=1.8.9,<2.0.0',
     'prompt-toolkit==0.52',
-    'boto3>=1.2.1',
-    'configobj>=5.0.6',
+    'boto3>=1.2.1,<2.0.0',
+    'configobj>=5.0.6,<6.0.0',
 ]
 
 


### PR DESCRIPTION
Just general future proofing.  Assuming the packages
follow semver (we do for boto3), we shouldn't jump up to
new major versions automatically.