### PR TITLE
Handle failure when unable to launch .edit editor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ you've run since you first started your aws-shell session.
 You can run the ``.edit`` command to open all these commands in
 an editor.  The aws-shell will use the ``EDITOR`` environment
 variable before defaulting to ``notepad`` on Windows and
-``vim`` on other platforms.
+``vi`` on other platforms.
 
 ::
 

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -65,13 +65,14 @@ class ChangeDirHandler(object):
 
 
 class EditHandler(object):
-    def __init__(self, popen_cls=None, env=None):
+    def __init__(self, popen_cls=None, env=None, err=sys.stderr):
         if popen_cls is None:
             popen_cls = subprocess.Popen
         self._popen_cls = popen_cls
         if env is None:
             env = os.environ
         self._env = env
+        self._err = err
 
     def _get_editor_command(self):
         if 'EDITOR' in self._env:
@@ -97,8 +98,14 @@ class EditHandler(object):
             f.write(all_commands)
             f.flush()
             editor = self._get_editor_command()
-            p = self._popen_cls([editor, f.name])
-            p.communicate()
+            try:
+                p = self._popen_cls([editor, f.name])
+                p.communicate()
+            except OSError:
+                self._err.write("Unable to launch editor: %s\n"
+                                "You can configure which editor to use by "
+                                "exporting the EDITOR environment variable.\n"
+                                % editor)
 
 
 class ProfileHandler(object):

--- a/awsshell/compat.py
+++ b/awsshell/compat.py
@@ -24,4 +24,4 @@ if ON_WINDOWS:
         return 'notepad.exe'
 else:
     def default_editor():
-        return 'vim'
+        return 'vi'

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -39,6 +39,20 @@ def test_edit_handler():
     assert command_run[0] == 'my-editor'
 
 
+def test_error_msg_printed_on_error_handler(errstream):
+    env = {'EDITOR': 'my-editor'}
+    popen_cls = mock.Mock()
+    popen_cls.side_effect = OSError()
+    context = mock.Mock()
+    context.history = []
+    handler = app.EditHandler(popen_cls, env, errstream)
+    handler.run(['.edit'], context)
+
+    # Then we should not propagate an exception, and we
+    # should print a helpful error message.
+    assert 'Unable to launch editor: my-editor' in errstream.getvalue()
+
+
 def test_profile_handler_prints_profile():
     shell = mock.Mock(spec=app.AWSShell)
     shell.profile = 'myprofile'


### PR DESCRIPTION
Fixes #88.

* Default editor to vi, not vim.  vi is available on more platforms.
* When we do fail, display a helpful error message instead of crashing.

New behavior:

```
$ EDITOR=some-bad-editor aws-shell
aws> .edit
Unable to launch editor: some-bad-editor
You can configure which editor to use by exporting the EDITOR environment variable.
```