### PR TITLE
Fixed auto completion for vault name

### DIFF
--- a/awsshell/data/glacier/2012-06-01/completions-1.json
+++ b/awsshell/data/glacier/2012-06-01/completions-1.json
@@ -55,7 +55,8 @@
     "Vault": {
       "operation": "ListVaults", 
       "resourceIdentifier": {
-        "AccountId": "accountId"
+        "AccountId": "accountId",
+        "Name": "VaultList[].VaultName"
       }
     }
   }


### PR DESCRIPTION
Hi,

I noticed that auto-completion was throwing an exception (cf below) for --vault-name.
I think the problem was that VaultName was not mapped correctly.

aws> glacier create-vault --vault-name 
Exception in thread Thread-68:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/dist-packages/prompt_toolkit/interface.py", line 624, in run
    CompleteEvent(text_inserted=True)))
  File "/usr/local/lib/python2.7/dist-packages/awsshell/shellcomplete.py", line 135, in get_completions                                                                                       
    .retrieve_candidate_values(service, operation, param)
  File "/usr/local/lib/python2.7/dist-packages/awsshell/resource/index.py", line 241, in retrieve_candidate_values
    service, api_operation_name, param)
  File "/usr/local/lib/python2.7/dist-packages/awsshell/resource/index.py", line 135, in describe_autocomplete
    path = resource_index['resourceIdentifier'][resource_identifier]
KeyError: u'Name'