### PR TITLE
Fix #113: Add Pygments>=2.1.3,<3.0.0 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ requires = [
     'prompt-toolkit==0.52',
     'boto3>=1.2.1,<2.0.0',
     'configobj>=5.0.6,<6.0.0',
+    'Pygments>=2.1.3,<3.0.0',
 ]
 
 


### PR DESCRIPTION
The problem and the fix are described here: https://github.com/awslabs/aws-shell/issues/113#issuecomment-205132744

Steps to verify fix:

* Have `Pygments` previously installed, say version `1.6`
     * `pip install Pygments==1.6`
* Install aws-shell, Pygments is updated to `2.1.3`
     * `pip install aws-shell`

`aws-shell` starts up without issues.

>As for the medium term, note the latest prompt-toolkit 0.60 has actually removed the Pygments dependency entirely: jonathanslenders/python-prompt-toolkit@401cbbb#diff-2eeaed663bd0d25b7e608891384b7298.

When we move to `prompt-toolkit>=0.60` we might need to revisit `Pygments`.  Seems the latest `prompt-toolkit` has similar support built-in.

```
awscli==1.10.17
boto3==1.3.0
botocore==1.4.8
colorama==0.3.3
configobj==5.0.6
docutils==0.12
jmespath==0.9.0
prompt-toolkit==0.52
pyasn1==0.1.9
Pygments==2.1.3
python-dateutil==2.5.2
rsa==3.3
s3transfer==0.0.1
six==1.10.0
wcwidth==0.1.6
wheel==0.24.0
```