### PR TITLE
Update index gen to use new API

### DIFF
--- a/awsshell/makeindex.py
+++ b/awsshell/makeindex.py
@@ -39,8 +39,12 @@ def index_command(index_dict, help_command):
             metadata['minidoc'] = remove_html(
                 arg_obj.documentation.split('\n')[0])
         if SHORTHAND_DOC.supports_shorthand(arg_obj.argument_model):
+            service_name, op_name = help_command.event_class.rsplit('.', 1)
             example = SHORTHAND_DOC.generate_shorthand_example(
-                arg, arg_obj.argument_model)
+                cli_argument=arg_obj,
+                service_name=service_name,
+                operation_name=op_name,
+            )
             metadata['example'] = example
 
         index_dict['arguments'].append('--%s' % arg)

--- a/tests/integration/test_makeindex.py
+++ b/tests/integration/test_makeindex.py
@@ -41,3 +41,9 @@ def test_can_document_all_service_commands(cloudformation_command):
     assert 'aws.cloudformation.create-stack' in db
     assert 'aws.cloudformation.delete-stack' in db
     assert 'SYNOPSIS' in db['aws.cloudformation.create-stack']
+
+
+def test_can_index_a_command(cloudformation_command):
+    help_command = cloudformation_command.create_help_command()
+    index = makeindex.new_index()
+    makeindex.index_command(index, help_command)


### PR DESCRIPTION
Shorthand example generator changed its signature,
so I've updated the aws shell to use the new API.

cc @donnemartin 