### PR TITLE
Bump minimum version of the AWS CLI to 1.10.30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 requires = [
-    'awscli>=1.8.9,<2.0.0',
+    'awscli>=1.10.30,<2.0.0',
     'prompt-toolkit>=1.0.0,<1.1.0',
     'boto3>=1.2.1,<2.0.0',
     'configobj>=5.0.6,<6.0.0',


### PR DESCRIPTION
This is now required because of the API change for
generating shorthand examples.


cc @donnemartin 