### PR TITLE
AWS Shell Wizards -- Base Commit

### DIFF
--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -147,6 +147,11 @@ class ExitHandler(object):
         return EXIT_REQUESTED
 
 
+class WizardHandler(object):
+    def run(self, command, application):
+        raise Exception("TODO")
+
+
 class DotCommandHandler(object):
     HANDLER_CLASSES = {
         'edit': EditHandler,
@@ -154,6 +159,7 @@ class DotCommandHandler(object):
         'cd': ChangeDirHandler,
         'exit': ExitHandler,
         'quit': ExitHandler,
+        'wizard': WizardHandler,
     }
 
     def __init__(self, output=sys.stdout, err=sys.stderr):

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -55,7 +55,7 @@ class ChangeDirHandler(object):
     def run(self, command, application):
         # command is a list of parsed commands
         if len(command) != 2:
-            self._err.write("invalid syntax, must be: .cd dirname\n")
+            self._err.write("Invalid syntax, must be: .cd dirname\n")
             return
         dirname = os.path.expandvars(os.path.expanduser(command[1]))
         try:
@@ -162,7 +162,7 @@ class WizardHandler(object):
         wizard.
         """
         if len(command) != 2:
-            self._err.write("invalid syntax, must be: .wizard wizname\n")
+            self._err.write("Invalid syntax, must be: .wizard wizname\n")
             return
         wizard = self._wizard_loader.load_wizard(command[1])
         wizard.execute()

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -25,6 +25,7 @@ from awsshell.style import StyleFactory
 from awsshell.toolbar import Toolbar
 from awsshell.utils import build_config_file_path, temporary_file
 from awsshell import compat
+from awsshell.wizard import WizardLoader
 
 
 LOG = logging.getLogger(__name__)
@@ -148,8 +149,23 @@ class ExitHandler(object):
 
 
 class WizardHandler(object):
+    def __init__(self, output=sys.stdout, err=sys.stderr):
+        self._output = output
+        self._err = err
+        self._wizard_loader = WizardLoader()
+
     def run(self, command, application):
-        raise Exception("TODO")
+        """Run the specified wizard.
+
+        Delegates to the wizard loader which will search various paths to find
+        a wizard model with a matching name. Returns and executes the loaded
+        wizard.
+        """
+        if len(command) != 2:
+            self._err.write("invalid syntax, must be: .wizard wizname\n")
+            return
+        wizard = self._wizard_loader.load_wizard(command[1])
+        wizard.execute()
 
 
 class DotCommandHandler(object):

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -1,95 +1,144 @@
-import re
+import sys
 import json
 import jmespath
 import botocore.session
+from botocore import xform_name
+from awsshell.resource import index
 
 
-# TODO copy pasta'd from stackoverflow... maybe we have something else?
-def camel_to_snake(name):
-    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+class WizardException(Exception):
+    """Base exception class for the Wizards"""
+    pass
+
+
+class WizardLoader(object):
+    """This class is responsible for searching various paths to locate wizard
+    models. Given a wizard name it will return a wizard object representing the
+    wizard. Delegates to botocore for finding and loading the JSON models.
+    """
+
+    def __init__(self):
+        self._session = botocore.session.get_session()
+        self._loader = self._session.get_component('data_loader')
+
+    def load_wizard(self, name):
+        """Given a wizard's name, returns an instance of that wizard.
+
+        :type name: str
+        :param name: The name of the desired wizard.
+        """
+        # TODO possible naming collisions here, always pick first for now
+        # Need to discuss and specify wizard invocation
+        services = self._loader.list_available_services(type_name=name)
+        model = self._loader.load_service_model(services[0], name)
+        return Wizard(model)
 
 
 class Wizard(object):
+    """The main wizard object containing all of the stages, the environment,
+    botocore sessions, and the logic to drive the wizards.
+    """
 
-    def __init__(self, filename=None):
-        self._env = Environment()
-        if filename:
-            self.load_from_json(filename)
+    def __init__(self, spec=None):
+        """Constructs a new Wizard
 
-    # Loads the wizards from the spec in dict form
-    def load_from_dict(self, spec):
-        self.start_stage = spec.get('StartStage')
-        # TODO if no start stage raise exception? default to first in array?
-        self.stages = {}
-        for s in spec['Stages']:
-            stage = Stage(s, self._env)
-            self.stages[stage.name] = stage
-
-    # TODO temporary loader from file, will likely deprecate this when
-    # there's a systemic way of loading all wizards in specified locations
-    def load_from_json(self, filename):
-        with open(filename, 'r') as f:
-            spec = json.load(f)
+        :type spec: dict
+        :param spec: (Optional) Constructs the wizard by loading the given
+        model specification.
+        """
+        self.env = Environment()
+        self._session = botocore.session.get_session()
+        self._cached_creator = index.CachedClientCreator(self._session)
+        if spec:
             self.load_from_dict(spec)
 
-    # Performs the basic loop for progressing stages
+    def load_from_dict(self, spec):
+        """Loads the model specification from a dict, populating the
+        wizard object.
+
+        :type spec: dict
+        :param spec: The model specification.
+
+        :raises: :class:`WizardException`
+        """
+        self.start_stage = spec.get('StartStage', None)
+        if not self.start_stage:
+            raise WizardException("Start stage not specified")
+        self.stages = {}
+        for s in spec['Stages']:
+            stage = Stage(s, self)
+            self.stages[stage.name] = stage
+
     def execute(self):
+        """Runs the wizard. Executes Stages until a final stage is reached.
+
+        :raises: :class:WizardException
+        """
         current_stage = self.start_stage
         while current_stage:
             stage = self.stages.get(current_stage, None)
             if not stage:
-                raise Exception("Stage does not exist: %s" % current_stage)
+                raise WizardException("Stage not found: %s" % current_stage)
             stage.execute()
             current_stage = stage.get_next_stage()
+        # TODO decouple wizard from all I/O
+        sys.stdout.write(str(self.env)+'\n')
 
 
 class Stage(object):
+    """The Stage object contains the meta information for a stage and logic
+    required to perform all steps present.
+    """
 
-    KEYS = ['Name', 'Prompt', 'Retrieval',
-            'Interaction', 'Resolution', 'NextStage']
+    def __init__(self, spec, wizard):
+        """Constructs a new Stage object.
 
-    def __init__(self, spec, env):
-        self._wizard_env = env
-        for key in Stage.KEYS:
-            setattr(self, camel_to_snake(key), spec.get(key, None))
+        :type spec: dict
+        :param spec: The stage specification model.
+
+        :type wizard: :class:`Wizard`
+        :param wizard: The wizard that this stage is a part of.
+        """
+        self._wizard = wizard
+        self.name = spec.get('Name', None)
+        self.prompt = spec.get('Prompt', None)
+        self.retrieval = spec.get('Retrieval', None)
+        self.next_stage = spec.get('NextStage', None)
+        self.resolution = spec.get('Resolution', None)
+        self.interaction = spec.get('Interaction', None)
 
     def __handle_static_retrieval(self):
         return self.retrieval.get('Resource')
 
     def __handle_request_retrieval(self):
-        # TODO very basic requests... refactor needed
         req = self.retrieval['Resource']
-        # initialize botocore session and client for service in the request
-        session = botocore.session.get_session()
-        client = session.create_client(req['Service'])
+        # get client from wizard's cache
+        client = self._wizard._cached_creator.create_client(req['Service'])
         # get the operation from the client
-        operation = getattr(client, camel_to_snake(req['Operation']))
+        operation = getattr(client, xform_name(req['Operation']))
         # get any parameters
         parameters = req.get('Parameters', {})
-        env_parameters = self._resolve_parameters(req.get('EnvParameters', {}))
+        env_parameters = \
+            self._wizard.env.resolve_parameters(req.get('EnvParameters', {}))
         # union of parameters and env_parameters, conflicts favor env_params
         parameters = dict(parameters, **env_parameters)
         # execute operation passing all parameters
-        result = operation(**parameters)
-        if self.retrieval.get('Path'):
-            result = jmespath.search(self.retrieval['Path'], result)
-        return result
+        return operation(**parameters)
 
     def _handle_retrieval(self):
-        print(self.prompt)
+        # TODO decouple wizard from all I/O
+        sys.stdout.write(self.prompt+'\n')
         # In case of no retrieval, empty dict
         if not self.retrieval:
             return {}
         elif self.retrieval['Type'] == 'Static':
-            return self.__handle_static_retrieval()
+            data = self.__handle_static_retrieval()
         elif self.retrieval['Type'] == 'Request':
-            return self.__handle_request_retreival()
-
-    def _resolve_parameters(self, keys):
-        for key in keys:
-            keys[key] = self._wizard_env.retrieve(keys[key])
-        return keys
+            data = self.__handle_request_retrieval()
+        # Apply JMESPath query if given
+        if self.retrieval.get('Path'):
+            data = jmespath.search(self.retrieval['Path'], data)
+        return data
 
     def _handle_interaction(self, data):
         # TODO actually implement this step
@@ -100,37 +149,82 @@ class Stage(object):
             data = data[0]
         elif self.interaction['ScreenType'] == 'SimplePrompt':
             for field in data:
-                data[field] = '500'
+                data[field] = 'random'
         return data
 
     def _handle_resolution(self, data):
         if self.resolution:
             if self.resolution.get('Path'):
                 data = jmespath.search(self.resolution['Path'], data)
-            self._wizard_env.store(self.resolution['Key'], data)
+            self._wizard.env.store(self.resolution['Key'], data)
 
     def get_next_stage(self):
+        """Resolves the next stage name for the stage after this one.
+
+        :rtype: str
+        :return: The name of the next stage.
+        """
         if not self.next_stage:
             return None
         elif self.next_stage['Type'] == 'Name':
             return self.next_stage['Name']
         elif self.next_stage['Type'] == 'Variable':
-            return self._wizard_env.retrieve(self.next_stage['Name'])
+            return self._wizard.env.retrieve(self.next_stage['Name'])
 
     # Executes all three steps of the stage
     def execute(self):
-        retrieved = self._handle_retrieval()
-        transformed = self._handle_interaction(retrieved)
-        self._handle_resolution(transformed)
+        """Executes all steps in the stage if they are present.
+        1) Perform Retrieval.
+        2) Perform Interaction on retrieved data.
+        3) Perform Resolution to store data in the environment.
+        """
+        retrieved_options = self._handle_retrieval()
+        selected_data = self._handle_interaction(retrieved_options)
+        self._handle_resolution(selected_data)
 
 
 class Environment(object):
+    """This class is used to store variables into a dict and retrieve them
+    via JMESPath queries instead of normal keys.
+    """
 
     def __init__(self):
         self._variables = {}
 
+    def __str__(self):
+        return json.dumps(self._variables, indent=4, sort_keys=True)
+
     def store(self, key, val):
+        """Stores a variable under the given key.
+
+        :type key: str
+        :param key: The key to store the value as.
+
+        :type val: object
+        :param val: The value to store into the environment.
+        """
         self._variables[key] = val
 
     def retrieve(self, path):
+        """Retrieves the variable corresponding to the given JMESPath query.
+
+        :type path: str
+        :param path: The JMESPath query to be used when locating the variable.
+        """
         return jmespath.search(path, self._variables)
+
+    def resolve_parameters(self, keys):
+        """Resolves all keys in the given keys dict. Expects all values in the
+        keys dict to be JMESPath queries to be used when retrieving from the
+        environment. Interpolates all values from their path to the actual
+        value stored in the environment.
+
+        :type keys: dict
+        :param keys: A dict of keys to paths that need to be resolved.
+
+        :rtype: dict
+        :return: The dict of with all of the paths resolved to their values.
+        """
+        for key in keys:
+            keys[key] = self.retrieve(keys[key])
+        return keys

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -7,105 +7,159 @@ from awsshell.resource import index
 
 
 class WizardException(Exception):
-    """Base exception class for the Wizards"""
+    """Base exception class for the Wizards."""
     pass
 
 
 class WizardLoader(object):
-    """This class is responsible for searching various paths to locate wizard
-    models. Given a wizard name it will return a wizard object representing the
-    wizard. Delegates to botocore for finding and loading the JSON models.
+    """This class is responsible for searching various paths to locate wizards.
+
+    Given a wizard name it will return a wizard object representing the wizard.
+    Delegates to botocore for finding and loading the JSON models.
     """
 
-    def __init__(self):
-        self._session = botocore.session.get_session()
+    def __init__(self, session=None):
+        """Initialize a wizard factory.
+
+        :type session: :class:`botocore.session.Session`
+        :param session: (Optional) The botocore session to be used when loading
+        models and retrieving clients.
+        """
+        self._session = session
+        if session is None:
+            self._session = botocore.session.Session()
         self._loader = self._session.get_component('data_loader')
 
     def load_wizard(self, name):
-        """Given a wizard's name, returns an instance of that wizard.
+        """Given a wizard's name, return an instance of that wizard.
 
         :type name: str
         :param name: The name of the desired wizard.
+
+        :rtype: :class:`Wizard`
+        :return: The wizard object loaded.
         """
         # TODO possible naming collisions here, always pick first for now
         # Need to discuss and specify wizard invocation
         services = self._loader.list_available_services(type_name=name)
         model = self._loader.load_service_model(services[0], name)
-        return Wizard(model)
+        return self.create_wizard(model)
 
+    def create_wizard(self, model):
+        """Given a wizard specification, return an instance of that wizard.
 
-class Wizard(object):
-    """The main wizard object containing all of the stages, the environment,
-    botocore sessions, and the logic to drive the wizards.
-    """
+        :type model: dict
+        :param model: The wizard specification to be used.
 
-    def __init__(self, spec=None):
-        """Constructs a new Wizard
-
-        :type spec: dict
-        :param spec: (Optional) Constructs the wizard by loading the given
-        model specification.
-        """
-        self.env = Environment()
-        self._session = botocore.session.get_session()
-        self._cached_creator = index.CachedClientCreator(self._session)
-        if spec:
-            self.load_from_dict(spec)
-
-    def load_from_dict(self, spec):
-        """Loads the model specification from a dict, populating the
-        wizard object.
-
-        :type spec: dict
-        :param spec: The model specification.
+        :rtype: :class:`Wizard`
+        :return: The wizard object created.
 
         :raises: :class:`WizardException`
         """
-        self.start_stage = spec.get('StartStage', None)
-        if not self.start_stage:
-            raise WizardException("Start stage not specified")
+        start_stage = model.get('StartStage')
+        if not start_stage:
+            raise WizardException('Start stage not specified')
+        stages = model.get('Stages')
+        return Wizard(start_stage, stages, self._session)
+
+
+class Wizard(object):
+    """Main wizard object. Contains main wizard driving logic."""
+
+    def __init__(self, start_stage, stages, session):
+        """Construct a new Wizard.
+
+        :type start_stage: str
+        :param start_stage: The name of the starting stage for the wizard.
+
+        :type stages: array of dict
+        :param stages: An array of stage models to generate stages from.
+
+        :type session: :class:`botocore.session.Session`
+        :param session: The botocore session to be used when creating clients.
+        """
+        self.env = Environment()
+        self._session = session
+        self._cached_creator = index.CachedClientCreator(self._session)
+        self.start_stage = start_stage
+        self._load_stages(stages)
+
+    def _load_stages(self, stages):
+        """Load the stages dictionary from the given array of stage models.
+
+        :type stages: array of dict
+        :param stages: An array of stage models to be converted into objects.
+        """
         self.stages = {}
-        for s in spec['Stages']:
-            stage = Stage(s, self)
+        for stage_model in stages:
+            stage_attrs = {
+                'name': stage_model.get('Name'),
+                'prompt': stage_model.get('Prompt'),
+                'retrieval': stage_model.get('Retrieval'),
+                'next_stage': stage_model.get('NextStage'),
+                'resolution': stage_model.get('Resolution'),
+                'interaction': stage_model.get('Interaction'),
+            }
+            stage = Stage(self.env, self._cached_creator, **stage_attrs)
             self.stages[stage.name] = stage
 
     def execute(self):
-        """Runs the wizard. Executes Stages until a final stage is reached.
+        """Run the wizard. Execute Stages until a final stage is reached.
 
-        :raises: :class:WizardException
+        :raises: :class:`WizardException`
         """
         current_stage = self.start_stage
         while current_stage:
-            stage = self.stages.get(current_stage, None)
+            stage = self.stages.get(current_stage)
             if not stage:
-                raise WizardException("Stage not found: %s" % current_stage)
+                raise WizardException('Stage not found: %s' % current_stage)
             stage.execute()
             current_stage = stage.get_next_stage()
         # TODO decouple wizard from all I/O
-        sys.stdout.write(str(self.env)+'\n')
+        sys.stdout.write(str(self.env) + '\n')
+        sys.stdout.flush()
 
 
 class Stage(object):
-    """The Stage object contains the meta information for a stage and logic
-    required to perform all steps present.
-    """
+    """The Stage object. Contains logic to run all steps of the stage."""
 
-    def __init__(self, spec, wizard):
-        """Constructs a new Stage object.
+    def __init__(self, env, creator, name=None, prompt=None, retrieval=None,
+                 next_stage=None, resolution=None, interaction=None):
+        """Construct a new Stage object.
 
-        :type spec: dict
-        :param spec: The stage specification model.
+        :type env: :class:`Environment`
+        :param env: The environment this stage is based in.
 
-        :type wizard: :class:`Wizard`
-        :param wizard: The wizard that this stage is a part of.
+        :type creator: :class:`CachedClientCreator`
+        :param creator: A botocore client creator that supports caching.
+
+        :type name: str
+        :param name: A unique identifier for the stage.
+
+        :type prompt: str
+        :param prompt: A simple message on the overall goal of the stage.
+
+        :type retrieval: dict
+        :param retrieval: The source of data for this stage.
+
+        :type next_stage: dict
+        :param next_stage: Describes what stage comes after this one.
+
+        :type resolution: dict
+        :param resolution: Describes what data to store in the environment.
+
+        :type interaction: dict
+        :param interaction: Describes what type of screen is to be used for
+        interaction.
         """
-        self._wizard = wizard
-        self.name = spec.get('Name', None)
-        self.prompt = spec.get('Prompt', None)
-        self.retrieval = spec.get('Retrieval', None)
-        self.next_stage = spec.get('NextStage', None)
-        self.resolution = spec.get('Resolution', None)
-        self.interaction = spec.get('Interaction', None)
+        self._env = env
+        self._cached_creator = creator
+        self.name = name
+        self.prompt = prompt
+        self.retrieval = retrieval
+        self.next_stage = next_stage
+        self.resolution = resolution
+        self.interaction = interaction
 
     def __handle_static_retrieval(self):
         return self.retrieval.get('Resource')
@@ -113,13 +167,13 @@ class Stage(object):
     def __handle_request_retrieval(self):
         req = self.retrieval['Resource']
         # get client from wizard's cache
-        client = self._wizard._cached_creator.create_client(req['Service'])
+        client = self._cached_creator.create_client(req['Service'])
         # get the operation from the client
         operation = getattr(client, xform_name(req['Operation']))
         # get any parameters
         parameters = req.get('Parameters', {})
         env_parameters = \
-            self._wizard.env.resolve_parameters(req.get('EnvParameters', {}))
+            self._env.resolve_parameters(req.get('EnvParameters', {}))
         # union of parameters and env_parameters, conflicts favor env_params
         parameters = dict(parameters, **env_parameters)
         # execute operation passing all parameters
@@ -127,7 +181,8 @@ class Stage(object):
 
     def _handle_retrieval(self):
         # TODO decouple wizard from all I/O
-        sys.stdout.write(self.prompt+'\n')
+        sys.stdout.write(self.prompt + '\n')
+        sys.stdout.flush()
         # In case of no retrieval, empty dict
         if not self.retrieval:
             return {}
@@ -156,10 +211,10 @@ class Stage(object):
         if self.resolution:
             if self.resolution.get('Path'):
                 data = jmespath.search(self.resolution['Path'], data)
-            self._wizard.env.store(self.resolution['Key'], data)
+            self._env.store(self.resolution['Key'], data)
 
     def get_next_stage(self):
-        """Resolves the next stage name for the stage after this one.
+        """Resolve the next stage name for the stage after this one.
 
         :rtype: str
         :return: The name of the next stage.
@@ -169,11 +224,12 @@ class Stage(object):
         elif self.next_stage['Type'] == 'Name':
             return self.next_stage['Name']
         elif self.next_stage['Type'] == 'Variable':
-            return self._wizard.env.retrieve(self.next_stage['Name'])
+            return self._env.retrieve(self.next_stage['Name'])
 
     # Executes all three steps of the stage
     def execute(self):
-        """Executes all steps in the stage if they are present.
+        """Execute all steps in the stage if they are present.
+
         1) Perform Retrieval.
         2) Perform Interaction on retrieved data.
         3) Perform Resolution to store data in the environment.
@@ -184,9 +240,7 @@ class Stage(object):
 
 
 class Environment(object):
-    """This class is used to store variables into a dict and retrieve them
-    via JMESPath queries instead of normal keys.
-    """
+    """Store vars into a dict and retrives them with JMESPath queries."""
 
     def __init__(self):
         self._variables = {}
@@ -195,7 +249,7 @@ class Environment(object):
         return json.dumps(self._variables, indent=4, sort_keys=True)
 
     def store(self, key, val):
-        """Stores a variable under the given key.
+        """Store a variable under the given key.
 
         :type key: str
         :param key: The key to store the value as.
@@ -206,7 +260,7 @@ class Environment(object):
         self._variables[key] = val
 
     def retrieve(self, path):
-        """Retrieves the variable corresponding to the given JMESPath query.
+        """Retrieve the variable corresponding to the given JMESPath query.
 
         :type path: str
         :param path: The JMESPath query to be used when locating the variable.
@@ -214,10 +268,11 @@ class Environment(object):
         return jmespath.search(path, self._variables)
 
     def resolve_parameters(self, keys):
-        """Resolves all keys in the given keys dict. Expects all values in the
-        keys dict to be JMESPath queries to be used when retrieving from the
-        environment. Interpolates all values from their path to the actual
-        value stored in the environment.
+        """Resolve all keys in the given keys dict.
+
+        Expects all values in the keys dict to be JMESPath queries to be used
+        when retrieving from the environment. Interpolates all values from
+        their path to the actual value stored in the environment.
 
         :type keys: dict
         :param keys: A dict of keys to paths that need to be resolved.

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -1,0 +1,136 @@
+import re
+import json
+import jmespath
+import botocore.session
+
+
+# TODO copy pasta'd from stackoverflow... maybe we have something else?
+def camel_to_snake(name):
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
+class Wizard(object):
+
+    def __init__(self, filename=None):
+        self._env = Environment()
+        if filename:
+            self.load_from_json(filename)
+
+    # Loads the wizards from the spec in dict form
+    def load_from_dict(self, spec):
+        self.start_stage = spec.get('StartStage')
+        # TODO if no start stage raise exception? default to first in array?
+        self.stages = {}
+        for s in spec['Stages']:
+            stage = Stage(s, self._env)
+            self.stages[stage.name] = stage
+
+    # TODO temporary loader from file, will likely deprecate this when
+    # there's a systemic way of loading all wizards in specified locations
+    def load_from_json(self, filename):
+        with open(filename, 'r') as f:
+            spec = json.load(f)
+            self.load_from_dict(spec)
+
+    # Performs the basic loop for progressing stages
+    def execute(self):
+        current_stage = self.start_stage
+        while current_stage:
+            stage = self.stages.get(current_stage, None)
+            if not stage:
+                raise Exception("Stage does not exist: %s" % current_stage)
+            stage.execute()
+            current_stage = stage.get_next_stage()
+
+
+class Stage(object):
+
+    KEYS = ['Name', 'Prompt', 'Retrieval',
+            'Interaction', 'Resolution', 'NextStage']
+
+    def __init__(self, spec, env):
+        self._wizard_env = env
+        for key in Stage.KEYS:
+            setattr(self, camel_to_snake(key), spec.get(key, None))
+
+    def __handle_static_retrieval(self):
+        return self.retrieval.get('Resource')
+
+    def __handle_request_retrieval(self):
+        # TODO very basic requests... refactor needed
+        req = self.retrieval['Resource']
+        # initialize botocore session and client for service in the request
+        session = botocore.session.get_session()
+        client = session.create_client(req['Service'])
+        # get the operation from the client
+        operation = getattr(client, camel_to_snake(req['Operation']))
+        # get any parameters
+        parameters = req.get('Parameters', {})
+        env_parameters = self._resolve_parameters(req.get('EnvParameters', {}))
+        # union of parameters and env_parameters, conflicts favor env_params
+        parameters = dict(parameters, **env_parameters)
+        # execute operation passing all parameters
+        result = operation(**parameters)
+        if self.retrieval.get('Path'):
+            result = jmespath.search(self.retrieval['Path'], result)
+        return result
+
+    def _handle_retrieval(self):
+        print(self.prompt)
+        # In case of no retrieval, empty dict
+        if not self.retrieval:
+            return {}
+        elif self.retrieval['Type'] == 'Static':
+            return self.__handle_static_retrieval()
+        elif self.retrieval['Type'] == 'Request':
+            return self.__handle_request_retreival()
+
+    def _resolve_parameters(self, keys):
+        for key in keys:
+            keys[key] = self._wizard_env.retrieve(keys[key])
+        return keys
+
+    def _handle_interaction(self, data):
+        # TODO actually implement this step
+        # if no interaction step, just forward data
+        if not self.interaction:
+            return data
+        elif self.interaction['ScreenType'] == 'SimpleSelect':
+            data = data[0]
+        elif self.interaction['ScreenType'] == 'SimplePrompt':
+            for field in data:
+                data[field] = '500'
+        return data
+
+    def _handle_resolution(self, data):
+        if self.resolution:
+            if self.resolution.get('Path'):
+                data = jmespath.search(self.resolution['Path'], data)
+            self._wizard_env.store(self.resolution['Key'], data)
+
+    def get_next_stage(self):
+        if not self.next_stage:
+            return None
+        elif self.next_stage['Type'] == 'Name':
+            return self.next_stage['Name']
+        elif self.next_stage['Type'] == 'Variable':
+            return self._wizard_env.retrieve(self.next_stage['Name'])
+
+    # Executes all three steps of the stage
+    def execute(self):
+        retrieved = self._handle_retrieval()
+        transformed = self._handle_interaction(retrieved)
+        self._handle_resolution(transformed)
+
+
+class Environment(object):
+
+    def __init__(self):
+        self._variables = {}
+
+    def store(self, key, val):
+        self._variables[key] = val
+
+    def retrieve(self, path):
+        return jmespath.search(path, self._variables)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -120,7 +120,7 @@ def test_chdir_syntax_error_prints_err_msg(errstream):
     chdir = mock.Mock()
     handler = app.ChangeDirHandler(err=errstream, chdir=chdir)
     handler.run(['.cd'], None)
-    assert 'invalid syntax' in errstream.getvalue()
+    assert 'Invalid syntax' in errstream.getvalue()
     assert not chdir.called
 
 

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -1,0 +1,86 @@
+import unittest
+from awsshell.wizard import Wizard
+from awsshell.wizard import Environment
+from awsshell.wizard import Stage
+
+
+class EnvironmentTest(unittest.TestCase):
+
+    # Set up a sample environment
+    def setUp(self):
+        self.var = {'epic': 'nice'}
+        self.env = Environment()
+        self.env.store('env_var', self.var)
+
+    # Test that the environment properly stores the given var
+    def test_environment_store(self):
+        self.assertEqual(self.env._variables.get('env_var'), self.var)
+
+    # Test that the env can retrieve keys via jmespath queries
+    def test_environment_retrieve(self):
+        self.assertEqual(self.env.retrieve('env_var'), self.var)
+        self.assertEqual(self.env.retrieve('env_var.epic'), 'nice')
+
+
+class StageTest(unittest.TestCase):
+
+    # Set up a sample stage
+    def setUp(self):
+        self.wiz = Wizard()
+        self.retrieval = {
+            'Type': 'Static',
+            'Resource': [
+                {'Option': 'Create new Api', 'Stage': 'CreateApi'},
+                {
+                    'Option': 'Generate new Api from swagger spec file',
+                    'Stage': 'NewSwaggerApi'
+                }
+            ]
+        }
+        self.interaction = {'ScreenType': 'SimpleSelect'},
+        self.resolution = {'Path': 'Stage', 'Key': 'CreationType'}
+        self.next_stage = {'Type': 'Variable', 'Name': 'CreationType'}
+        self.stage_spec = {
+            'Name': 'ApiSourceSwitch',
+            'Prompt': 'Prompting',
+            'Retrieval': self.retrieval,
+            'Interaction': self.interaction,
+            'Resolution': self.resolution,
+            'NextStage': self.next_stage
+        }
+
+    # Test that the spec is translated to the correct attrs
+    def test_from_spec(self):
+        test_env = Environment()
+        stage = Stage(self.stage_spec, test_env)
+        self.assertEqual(stage.name, 'ApiSourceSwitch')
+        self.assertEqual(stage.prompt, 'Prompting')
+        self.assertEqual(stage.retrieval, self.retrieval)
+        self.assertEqual(stage.interaction, self.interaction)
+        self.assertEqual(stage.resolution, self.resolution)
+        self.assertEqual(stage.next_stage, self.next_stage)
+
+    # Test that static retrieval reads the data straight from the spec
+    def test_static_retrieval(self):
+        test_env = Environment()
+        stage = Stage(self.stage_spec, test_env)
+        ret = stage._handle_retrieval()
+        self.assertEqual(ret, self.retrieval['Resource'])
+
+    # Test that resolution properly puts the resolved value into the env
+    def test_handle_resolution(self):
+        test_env = Environment()
+        stage = Stage(self.stage_spec, test_env)
+        data = {'Stage': 'EpicNice'}
+        stage._handle_resolution(data)
+        self.assertEqual(test_env.retrieve('CreationType'), 'EpicNice')
+
+    # Test that env paramaters can be resolved for the stage
+    def test_resolve_parameters(self):
+        test_env = Environment()
+        test_env.store('Epic', 'Nice')
+        test_env.store('Test', {'k': 'v'})
+        keys = {'a': 'Epic', 'b': 'Test.k'}
+        stage = Stage(self.stage_spec, test_env)
+        resolved = stage._resolve_parameters(keys)
+        self.assertEqual(resolved, {'a': 'Nice', 'b': 'v'})

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -1,5 +1,6 @@
+import mock
 import pytest
-from awsshell.wizard import Environment, Wizard
+from awsshell.wizard import Environment, WizardLoader, WizardException
 
 
 @pytest.fixture
@@ -32,6 +33,12 @@ def test_resolve_parameters():
 
 
 @pytest.fixture
+def loader(wizard_spec):
+    session = mock.Mock()
+    return WizardLoader(session)
+
+
+@pytest.fixture
 def wizard_spec():
     return {
         'StartStage': 'TestStage',
@@ -48,14 +55,53 @@ def wizard_spec():
                 },
                 'Resolution': {'Path': 'Stage', 'Key': 'CreationType'},
                 'NextStage': {'Type': 'Variable', 'Name': 'CreationType'}
+            },
+            {
+                'Name': 'StageTwo',
+                'Prompt': 'Prompting Too'
             }
         ]
     }
 
 
-def test_from_spec(wizard_spec):
+@pytest.fixture
+def wizard_spec_request():
+    return {
+        'StartStage': 'TestStage',
+        'Stages': [
+            {
+                'Name': 'TestStage',
+                'Prompt': 'Prompting',
+                'Retrieval': {
+                    'Type': 'Static',
+                    'Resource': {'ApiName': 'new api name'}
+                },
+                'Resolution': {'Path': 'ApiName', 'Key': 'ApiName'},
+                'NextStage': {'Type': 'Name', 'Name': 'StageTwo'}
+            },
+            {
+                'Name': 'StageTwo',
+                'Prompt': 'Prompting',
+                'Retrieval': {
+                    'Type': 'Request',
+                    'Resource': {
+                        'Service': 'apigateway',
+                        'Operation':
+                        'CreateRestApi',
+                        'Parameters': {'param': 'value'},
+                        'EnvParameters': {'name': 'ApiName'}
+                    }
+                },
+                'Resolution': {'Path': 'id', 'Key': 'CreatedId'},
+                'NextStage': {'Type': 'Variable', 'Name': 'CreationType'}
+            }
+        ]
+    }
+
+
+def test_from_spec(wizard_spec, loader):
     # Test that the spec is translated to the correct attrs
-    wizard = Wizard(wizard_spec)
+    wizard = loader.create_wizard(wizard_spec)
     stage_spec = wizard_spec['Stages'][0]
     stage = wizard.stages['TestStage']
     assert stage.prompt == 'Prompting'
@@ -66,40 +112,107 @@ def test_from_spec(wizard_spec):
     assert not stage.interaction
 
 
-def test_static_retrieval(wizard_spec):
+def test_static_retrieval(wizard_spec, loader):
     # Test that static retrieval reads the data from the spec and resolves into
     # the wizard's environment under the correct key
     wizard_spec['Stages'][0]['Resolution'] = {'Key': 'CreationType'}
-    wizard = Wizard(wizard_spec)
+    wizard = loader.create_wizard(wizard_spec)
     stage = wizard.stages['TestStage']
     stage.execute()
     assert stage.retrieval['Resource'] == wizard.env.retrieve('CreationType')
 
 
-def test_static_retrieval_with_query(wizard_spec):
+def test_static_retrieval_with_query(wizard_spec, loader):
     # Test that static retrieval reads the data and can apply a JMESpath query
     wizard_spec['Stages'][0]['Retrieval']['Path'] = '[0].Stage'
     wizard_spec['Stages'][0]['Resolution'] = {'Key': 'CreationType'}
-    wizard = Wizard(wizard_spec)
+    wizard = loader.create_wizard(wizard_spec)
     stage = wizard.stages['TestStage']
     stage.execute()
     assert wizard.env.retrieve('CreationType') == 'StageOne'
 
 
-def test_next_stage_resolution(wizard_spec):
+def test_request_retrieval(wizard_spec_request):
+    # Tests that retrieval requests are parsed and call the correct operation
+    mock_session = mock.Mock()
+    mock_request = mock_session.create_client.return_value.create_rest_api
+    mock_request.return_value = {'id': 'api id', 'name': 'random name'}
+
+    loader = WizardLoader(mock_session)
+    wizard = loader.create_wizard(wizard_spec_request)
+    wizard.execute()
+    mock_request.assert_called_once_with(param='value', name='new api name')
+
+
+def test_next_stage_resolution(wizard_spec, loader):
     # Test that the stage can resolve the next stage from env
     wizard_spec['Stages'][0]['Retrieval']['Path'] = '[0]'
-    wizard = Wizard(wizard_spec)
+    wizard = loader.create_wizard(wizard_spec)
     stage = wizard.stages['TestStage']
     stage.execute()
     assert stage.get_next_stage() == 'StageOne'
 
 
-def test_next_stage_static(wizard_spec):
+def test_next_stage_static(wizard_spec, loader):
     # Test that the stage can resolve static next stage
     wizard_spec['Stages'][0]['NextStage'] = \
         {'Type': 'Name', 'Name': 'NextStageName'}
-    wizard = Wizard(wizard_spec)
+    wizard = loader.create_wizard(wizard_spec)
     stage = wizard.stages['TestStage']
     stage.execute()
     assert stage.get_next_stage() == 'NextStageName'
+
+
+def test_basic_full_execution(wizard_spec, loader):
+    # Test that the wizard can advance stages and finish a wizard
+    wizard_spec['Stages'][0]['NextStage'] = \
+        {'Type': 'Name', 'Name': 'StageTwo'}
+    wizard_spec['Stages'][0]['Resolution']['Path'] = '[0].Stage'
+    wizard = loader.create_wizard(wizard_spec)
+    wizard.execute()
+    display_str = '{\n    "CreationType": "StageOne"\n}'
+    assert str(wizard.env) == display_str
+
+
+def test_missing_start_stage(wizard_spec, loader):
+    # Test that the loader throws an error if the spec is missing start stage
+    wizard_spec['StartStage'] = None
+    with pytest.raises(WizardException) as we:
+        loader.create_wizard(wizard_spec)
+    assert 'Start stage not specified' in str(we.value)
+
+
+def test_missing_stage(wizard_spec, loader):
+    # Test that the loader throws an error if the spec is missing start stage
+    wizard_spec['Stages'][0]['NextStage'] = \
+        {'Type': 'Name', 'Name': 'ImpendingDoom'}
+    wizard = loader.create_wizard(wizard_spec)
+    with pytest.raises(WizardException) as we:
+        wizard.execute()
+    assert 'Stage not found: ImpendingDoom' in str(we.value)
+
+
+def test_wizard_loader(wizard_spec):
+    # Tests that the wizard loader can access models via the botocore loader
+    mock_session = mock.Mock()
+    mock_loader = mock_session.get_component.return_value
+    mock_loader.list_available_services.return_value = ['wizards']
+    mock_loader.load_service_model.return_value = wizard_spec
+    loader = WizardLoader(mock_session)
+
+    w1 = loader.load_wizard('wizname')
+    w2 = loader.create_wizard(wizard_spec)
+
+    mock_session.get_component.assert_called_once_with('data_loader')
+    mock_list = mock_loader.list_available_services
+    mock_model = mock_loader.load_service_model
+    mock_list.assert_called_once_with(type_name='wizname')
+    mock_model.assert_called_once_with('wizards', 'wizname')
+    assert w1.start_stage == w2.start_stage
+
+
+def test_wizard_loader_no_session(wizard_spec, loader):
+    test_loader = WizardLoader()
+    w1 = test_loader.create_wizard(wizard_spec)
+    w2 = loader.create_wizard(wizard_spec)
+    assert w1.start_stage == w2.start_stage


### PR DESCRIPTION
### What has been done and has tests:
* Reading JSON files to dict (basic implementation)
* Converting dict to Python objects
* Creating an Environment that supports storing and retrieval via JMESPath queries
* Applying JMESPath queries to retrieved data
* Getting the next stage via a JMESPath query on the environment or static name
* Resolving an EnvParameters object 

### Additional functionality
Beyond the backlog features above, some additional functionality has been given (basic) implementations to give some context for the above features. ~~These do not have tests as they require a functioning interaction step (at least mocking them).~~
Edit: After review all functionality below has unit tests as well.
* Wizard loop -- can execute basic wizard specs from start to finish performing each stage
* Basic request retrieval -- can connect with botocore to make service calls
* Stage execution -- can perform all steps of the stage and handle data transformations. Interactions are currently hard coded.
