### PR TITLE
Handle exceptions in Wizards gracefully

### DIFF
--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -25,7 +25,9 @@ from awsshell.style import StyleFactory
 from awsshell.toolbar import Toolbar
 from awsshell.utils import build_config_file_path, temporary_file
 from awsshell import compat
-from awsshell.wizard import WizardLoader
+from awsshell.interaction import InteractionException
+from awsshell.wizard import WizardLoader, WizardException
+from botocore.exceptions import ClientError
 
 
 LOG = logging.getLogger(__name__)
@@ -164,8 +166,17 @@ class WizardHandler(object):
         if len(command) != 2:
             self._err.write("Invalid syntax, must be: .wizard wizname\n")
             return
-        wizard = self._wizard_loader.load_wizard(command[1])
-        wizard.execute()
+        try:
+            wizard = self._wizard_loader.load_wizard(command[1])
+            wizard.execute()
+
+        except (ClientError) as err:
+            self._err.write("{0}\n".format(err))
+        except (WizardException, InteractionException) as err:
+            self._err.write("An error occurred: {0}\n".format(err))
+        # EOF or Ctrl-C in a wizard drop back to shell
+        except (KeyboardInterrupt, EOFError):
+            pass
 
 
 class DotCommandHandler(object):

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -25,9 +25,7 @@ from awsshell.style import StyleFactory
 from awsshell.toolbar import Toolbar
 from awsshell.utils import build_config_file_path, temporary_file
 from awsshell import compat
-from awsshell.interaction import InteractionException
-from awsshell.wizard import WizardLoader, WizardException
-from botocore.exceptions import ClientError
+from awsshell.wizard import WizardLoader
 
 
 LOG = logging.getLogger(__name__)
@@ -151,10 +149,11 @@ class ExitHandler(object):
 
 
 class WizardHandler(object):
-    def __init__(self, output=sys.stdout, err=sys.stderr):
+    def __init__(self, output=sys.stdout, err=sys.stderr,
+                 loader=WizardLoader()):
         self._output = output
         self._err = err
-        self._wizard_loader = WizardLoader()
+        self._wizard_loader = loader
 
     def run(self, command, application):
         """Run the specified wizard.
@@ -169,14 +168,12 @@ class WizardHandler(object):
         try:
             wizard = self._wizard_loader.load_wizard(command[1])
             wizard.execute()
-
-        except (ClientError) as err:
-            self._err.write("{0}\n".format(err))
-        except (WizardException, InteractionException) as err:
-            self._err.write("An error occurred: {0}\n".format(err))
-        # EOF or Ctrl-C in a wizard drop back to shell
+        # EOF or Ctrl-C in a wizard drop back to shell silently
         except (KeyboardInterrupt, EOFError):
             pass
+        # For any other exception, print it and return to shell
+        except Exception as err:
+            self._err.write("{0}\n".format(err))
 
 
 class DotCommandHandler(object):

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -86,8 +86,11 @@ class WizardLoader(object):
         # TODO possible naming collisions here, always pick first for now
         # Need to discuss and specify wizard invocation
         services = self._loader.list_available_services(type_name=name)
-        model = self._loader.load_service_model(services[0], name)
-        return self.create_wizard(model)
+        if len(services) == 0:
+            raise WizardException('Wizard with name %s does not exist' % name)
+        else:
+            model = self._loader.load_service_model(services[0], name)
+            return self.create_wizard(model)
 
     def create_wizard(self, model):
         """Given a wizard specification, return an instance of that wizard.

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -6,6 +6,11 @@ from awsshell import app
 from awsshell import shellcomplete
 from awsshell import compat
 
+from awsshell.utils import FileReadError
+from awsshell.wizard import WizardException
+from awsshell.interaction import InteractionException
+from botocore.exceptions import ClientError, BotoCoreError
+
 
 @pytest.fixture
 def errstream():
@@ -14,6 +19,7 @@ def errstream():
 
 def test_can_dispatch_dot_commands():
     call_args = []
+
     class CustomHandler(object):
         def run(self, command, context):
             call_args.append((command, context))
@@ -146,3 +152,59 @@ def test_exit_dot_command_exits_shell():
     # see the .quit command, we immediately exit and stop prompting
     # for more shell commands.
     assert mock_prompter.run.call_count == 1
+
+
+def test_wizard_can_load_and_execute():
+    # Proper dot command syntax should load and run a wizard
+    mock_loader = mock.Mock()
+    mock_wizard = mock_loader.load_wizard.return_value
+    handler = app.WizardHandler(err=errstream, loader=mock_loader)
+    handler.run(['.wizard', 'wizname'], None)
+
+    assert mock_wizard.execute.call_count == 1
+    assert mock_loader.load_wizard.call_count == 1
+    mock_loader.load_wizard.assert_called_with('wizname')
+
+
+def test_wizard_syntax_error_prints_err_msg(errstream):
+    # Invalid wizard syntax should print error and not load a wizard
+    mock_loader = mock.Mock()
+    handler = app.WizardHandler(err=errstream, loader=mock_loader)
+    handler.run(['.wizard'], None)
+    assert 'Invalid syntax' in errstream.getvalue()
+    assert not mock_loader.load_wizard.called
+
+
+@pytest.mark.parametrize('err', [EOFError(), KeyboardInterrupt()])
+def test_wizard_handles_eof_interrupt(err, errstream):
+    # EOF and Keyboard should silently drop back to the shell
+    mock_loader = mock.Mock()
+    mock_loader.load_wizard.side_effect = err
+    handler = app.WizardHandler(err=errstream, loader=mock_loader)
+    try:
+        handler.run(['.wizard', 'name'], None)
+    except:
+        pytest.fail('No exception should have been thrown')
+    assert errstream.getvalue() == ''
+
+
+exceptions = [
+    BotoCoreError(),
+    FileReadError('error'),
+    WizardException('error'),
+    InteractionException('error'),
+    ClientError({'Error': {}}, 'Operation')
+]
+
+
+@pytest.mark.parametrize('err', exceptions)
+def test_wizard_handles_exceptions(err, errstream):
+    # Test that exceptions are caught and an error message is displayed
+    mock_loader = mock.Mock()
+    mock_loader.load_wizard.side_effect = err
+    handler = app.WizardHandler(err=errstream, loader=mock_loader)
+    try:
+        handler.run(['.wizard', 'name'], None)
+    except:
+        pytest.fail('No exception should have been thrown')
+    assert 'error' in errstream.getvalue()

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -235,6 +235,16 @@ def test_wizard_loader(wizard_spec):
     assert w1.start_stage == w2.start_stage
 
 
+def test_wizard_loader_not_found():
+    mock_session = mock.Mock()
+    mock_loader = mock_session.get_component.return_value
+    mock_loader.list_available_services.return_value = []
+    loader = WizardLoader(mock_session)
+    with pytest.raises(WizardException) as we:
+        loader.load_wizard('wizname')
+    assert 'Wizard with name wizname does not exist' in str(we.value)
+
+
 def test_wizard_loader_no_session(wizard_spec, loader):
     # Test that the wizard loader still functions without a given session
     test_loader = WizardLoader()


### PR DESCRIPTION
Common and known exceptions will display reasonable error messages and drop back down to the shell. Also added unit tests for the Wizard Handler in the main application that were previously missing.

cc @JordonPhillips 