### PR TITLE
Select Menu Implementation and Integration

### DIFF
--- a/awsshell/interaction.py
+++ b/awsshell/interaction.py
@@ -74,9 +74,9 @@ class SimpleSelect(Interaction):
         if not isinstance(data, list) or len(data) < 1:
             raise InteractionException('SimpleSelect expects a non-empty list')
         if self._model.get('Path') is not None:
-            disp_data = jmespath.search(self._model['Path'], data)
-            option_dict = dict(zip(disp_data, data))
-            selected = self._prompter('%s ' % self.prompt, disp_data)
+            display_data = jmespath.search(self._model['Path'], data)
+            option_dict = dict(zip(display_data, data))
+            selected = self._prompter('%s ' % self.prompt, display_data)
             return option_dict[selected]
         else:
             return self._prompter('%s ' % self.prompt, data)

--- a/awsshell/interaction.py
+++ b/awsshell/interaction.py
@@ -6,9 +6,9 @@ from six import with_metaclass
 from abc import ABCMeta, abstractmethod
 
 from prompt_toolkit import prompt
-from prompt_toolkit.contrib.completers import WordCompleter, PathCompleter
-
+from prompt_toolkit.contrib.completers import PathCompleter
 from awsshell.utils import FSLayer
+from awsshell.selectmenu import select_prompt
 
 
 class InteractionException(Exception):
@@ -66,7 +66,7 @@ class SimpleSelect(Interaction):
     used as is.
     """
 
-    def __init__(self, model, prompt_msg, prompter=prompt):
+    def __init__(self, model, prompt_msg, prompter=select_prompt):
         super(SimpleSelect, self).__init__(model, prompt_msg)
         self._prompter = prompter
 
@@ -74,18 +74,12 @@ class SimpleSelect(Interaction):
         if not isinstance(data, list) or len(data) < 1:
             raise InteractionException('SimpleSelect expects a non-empty list')
         if self._model.get('Path') is not None:
-            display_data = jmespath.search(self._model['Path'], data)
-            completer = WordCompleter(
-                display_data,
-                sentence=True,
-                ignore_case=True
-            )
-            option_dict = dict(zip(display_data, data))
-            selected = self._prompter('%s ' % self.prompt, completer=completer)
+            disp_data = jmespath.search(self._model['Path'], data)
+            option_dict = dict(zip(disp_data, data))
+            selected = self._prompter('%s ' % self.prompt, disp_data)
             return option_dict[selected]
         else:
-            cmpltr = WordCompleter(data, ignore_case=True, sentence=True)
-            return self._prompter('%s ' % self.prompt, completer=cmpltr)
+            return self._prompter('%s ' % self.prompt, data)
 
 
 class SimplePrompt(Interaction):

--- a/awsshell/interaction.py
+++ b/awsshell/interaction.py
@@ -75,11 +75,12 @@ class SimpleSelect(Interaction):
             raise InteractionException('SimpleSelect expects a non-empty list')
         if self._model.get('Path') is not None:
             display_data = jmespath.search(self._model['Path'], data)
-            option_dict = dict(zip(display_data, data))
-            selected = self._prompter('%s ' % self.prompt, display_data)
-            return option_dict[selected]
+            result = self._prompter('%s ' % self.prompt, display_data)
+            (selected, index) = result
+            return data[index]
         else:
-            return self._prompter('%s ' % self.prompt, data)
+            (selected, index) = self._prompter('%s ' % self.prompt, data)
+            return selected
 
 
 class SimplePrompt(Interaction):

--- a/awsshell/selectmenu.py
+++ b/awsshell/selectmenu.py
@@ -1,0 +1,262 @@
+import json
+from pygments.lexers import find_lexer_class
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.token import Token
+from prompt_toolkit.filters import IsDone
+from prompt_toolkit.utils import get_cwidth
+from prompt_toolkit.document import Document
+from prompt_toolkit.enums import DEFAULT_BUFFER
+from prompt_toolkit.interface import Application
+from prompt_toolkit.filters import to_simple_filter
+from prompt_toolkit.layout.screen import Point, Char
+from prompt_toolkit.shortcuts import run_application
+from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.layout.prompt import DefaultPrompt
+from prompt_toolkit.buffer import Buffer, AcceptAction
+from prompt_toolkit.layout.controls import BufferControl
+from prompt_toolkit.layout.margins import ScrollbarMargin
+from prompt_toolkit.layout.dimension import LayoutDimension
+from prompt_toolkit.key_binding.manager import KeyBindingManager
+from prompt_toolkit.layout.controls import UIControl, UIContent, FillControl
+from prompt_toolkit.layout import Window, HSplit, FloatContainer, Float
+from prompt_toolkit.layout.containers import ScrollOffsets, \
+    ConditionalContainer
+
+
+class SelectMenuControl(UIControl):
+    """Given a list, display that list as a drop down menu."""
+
+    # 7 because that's what the default prompt uses
+    MIN_WIDTH = 7
+
+    def __init__(self, options):
+        self.token = Token.Menu.Completions
+        self._options = options
+        # Add two to give the list some breathing room
+        self.width = max(get_cwidth(o) for o in self._options) + 2
+        self.width = max(self.width, self.MIN_WIDTH)
+        self.height = len(options)
+        self._selection = None
+
+    def get_selection(self):
+        """Return the currently selected option, if there is one."""
+        if self._selection is not None:
+            return self._options[self._selection]
+        else:
+            return None
+
+    def select_down(self, event=None):
+        """Cycle down the list of options by one."""
+        if self._selection is not None:
+            self._selection = (self._selection + 1) % self.height
+        else:
+            self._selection = 0
+        self._insert_text(event)
+
+    def select_up(self, event=None):
+        """Cycle up the list of options by one."""
+        if self._selection is not None:
+            self._selection -= 1
+            if self._selection < 0:
+                self._selection = self.height - 1
+        else:
+            self._selection = self.height - 1
+        self._insert_text(event)
+
+    def _insert_text(self, event):
+        if event is not None:
+            event.current_buffer.document = Document(self.get_selection())
+
+    def preferred_width(self, cli, max_available_width):
+        """Return the preferred width of this UIControl."""
+        return self.width
+
+    def preferred_height(self, cli, width, max_available_height, wrap_lines):
+        """Return the preferred height of this UIControl."""
+        return self.height
+
+    def create_content(self, cli, width, height):
+        """Generate the UIContent for this control.
+
+        Create a get_line function that returns how each line of this control
+        should be rendered.
+        """
+        def get_line(i):
+            c = self._options[i]
+            is_current = (i == self._selection)
+            # Render the line as array of tokens for highlighting
+            return self._get_menu_item_tokens(c, is_current)
+
+        return UIContent(
+            get_line=get_line,
+            line_count=self.height,
+            default_char=Char(' ', self.token),
+            cursor_position=Point(x=0, y=self._selection or 0)
+        )
+
+    def _get_menu_item_tokens(self, option, is_current):
+        """Given an option generate the proper token list for highlighting."""
+        # highlight the current selection with a different token
+        if is_current:
+            token = self.token.Completion.Current
+        else:
+            token = self.token.Completion
+        # pad all lines to the same width
+        padding = ' ' * (self.width - len(option))
+        return [(token, ' %s%s ' % (option, padding))]
+
+
+def create_select_menu_layout(msg, menu_control,
+                              show_meta=False,
+                              reserve_space_for_menu=True):
+    """Construct a layout for the given message and menu control."""
+    def get_prompt_tokens(_):
+        return [(Token.Prompt, msg)]
+
+    # Ensures that the menu has enough room to display it's options
+    def get_prompt_height(cli):
+        if reserve_space_for_menu and not cli.is_done:
+            return LayoutDimension(min=8)
+        else:
+            return LayoutDimension()
+
+    input_processors = [DefaultPrompt(get_prompt_tokens)]
+    prompt_layout = FloatContainer(
+        HSplit([
+            Window(
+                BufferControl(input_processors=input_processors),
+                get_height=get_prompt_height
+            )
+        ]),
+        [
+            Float(
+                # Display the prompt starting below the cursor
+                left=len(msg),
+                ycursor=True,
+                content=ConditionalContainer(
+                    content=Window(
+                        content=menu_control,
+                        # only display 1 - 7 lines of completions
+                        height=LayoutDimension(min=1, max=7),
+                        # display a scroll bar
+                        scroll_offsets=ScrollOffsets(top=0, bottom=0),
+                        right_margins=[ScrollbarMargin()],
+                        # don't make the menu wider than the options
+                        dont_extend_width=True
+                    ),
+                    # Only display the prompt while the buffer is relevant
+                    filter=~IsDone()
+                )
+            )
+        ]
+    )
+
+    # Show meta information with the buffer isn't done and show_meta is True
+    meta_filter = ~IsDone() & to_simple_filter(show_meta)
+    return HSplit([
+        prompt_layout,
+        ConditionalContainer(
+            filter=meta_filter,
+            content=Window(
+                height=LayoutDimension.exact(1),
+                content=FillControl(u'\u2500', token=Token.Line)
+            )
+        ),
+        ConditionalContainer(
+            filter=meta_filter,
+            content=Window(
+                # Meta information takes up at most 15 lines
+                height=LayoutDimension(max=15),
+                content=BufferControl(
+                    buffer_name='INFO',
+                    # TODO discuss pygments import voodoo
+                    lexer=PygmentsLexer(find_lexer_class('JSON'))
+                )
+            ),
+        )
+    ])
+
+
+class SelectMenuApplication(Application):
+    """Wrap Application, providing the correct layout, keybindings, etc."""
+
+    def __init__(self, message, options, *args, **kwargs):
+        self._menu_control = SelectMenuControl(options)
+
+        self.kb_manager = KeyBindingManager(
+            enable_system_bindings=True,
+            enable_abort_and_exit_bindings=True
+        )
+        menu_control = self._menu_control
+        options_meta = kwargs.pop('options_meta', None)
+
+        # Return the currently selected option
+        def return_selection(cli, buf):
+            cli.set_return_value(menu_control.get_selection())
+
+        buffers = {}
+
+        def_buf = Buffer(
+            initial_document=Document(''),
+            accept_action=AcceptAction(return_selection)
+        )
+
+        buffers[DEFAULT_BUFFER] = def_buf
+
+        show_meta = options_meta is not None
+        # Optionally show meta information if present
+        if show_meta:
+            info_buf = Buffer(is_multiline=True)
+            buffers['INFO'] = info_buf
+
+            def selection_changed(cli):
+                info = options_meta[buffers[DEFAULT_BUFFER].text]
+                formatted_info = json.dumps(info, indent=4, sort_keys=True)
+                buffers['INFO'].text = formatted_info
+            def_buf.on_text_changed += selection_changed
+
+        # Apply the correct buffers, key bindings, and layout before super call
+        kwargs['buffers'] = buffers
+        kwargs['key_bindings_registry'] = self.kb_manager.registry
+        kwargs['layout'] = create_select_menu_layout(
+            message,
+            menu_control,
+            show_meta=show_meta
+        )
+        self._bind_keys(self.kb_manager.registry, self._menu_control)
+        super(SelectMenuApplication, self).__init__(*args, **kwargs)
+
+    def _bind_keys(self, registry, menu_control):
+        handle = registry.add_binding
+
+        @handle(Keys.F10)
+        def handle_f10(event):
+            event.cli.set_exit()
+
+        @handle(Keys.Up)
+        @handle(Keys.BackTab)
+        def handle_up(event):
+            menu_control.select_up(event=event)
+
+        @handle(Keys.Tab)
+        @handle(Keys.Down)
+        def handle_down(event):
+            menu_control.select_down(event=event)
+
+        @handle(Keys.ControlJ)
+        def accept(event):
+            buff = event.current_buffer
+            selection = menu_control.get_selection()
+            if selection is not None:
+                buff.accept_action.validate_and_handle(event.cli, buff)
+
+        @handle(Keys.Any)
+        @handle(Keys.Backspace)
+        def _(_):
+            pass
+
+
+def select_prompt(message, options, *args, **kwargs):
+    """Construct and run the select menu application, returning the result."""
+    app = SelectMenuApplication(message, options, *args, **kwargs)
+    return run_application(app)

--- a/tests/integration/test_selectmenu.py
+++ b/tests/integration/test_selectmenu.py
@@ -1,0 +1,87 @@
+import mock
+import pytest
+
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.token import Token
+from prompt_toolkit.document import Document
+from prompt_toolkit.enums import DEFAULT_BUFFER
+from prompt_toolkit.shortcuts import create_eventloop
+from prompt_toolkit.interface import CommandLineInterface
+from prompt_toolkit.key_binding.input_processor import KeyPress
+
+from awsshell.selectmenu import SelectMenuApplication
+
+
+@pytest.fixture
+def cli():
+    app = SelectMenuApplication(u'prompt', [u'1', u'2', u'3'])
+    return CommandLineInterface(application=app, eventloop=create_eventloop())
+
+
+def feed_key(cli, key, data=u''):
+    cli.input_processor.feed(KeyPress(key, data))
+    cli.input_processor.process_keys()
+
+
+def test_select_menu_layout(cli):
+    layout = cli.application.layout
+    prompt_window = layout.children[0].content.children[0]
+    buffer_control = prompt_window.content
+    get_tokens = buffer_control.input_processors[0].get_tokens
+    assert callable(get_tokens)
+    assert get_tokens(mock.Mock) == [(Token.Prompt, 'prompt')]
+    height = prompt_window.preferred_height(cli, 100, 20)
+    # assert that the menu reserves space
+    assert height.min == height.preferred == 8
+    cli.set_exit()
+    height = prompt_window.preferred_height(cli, 100, 20)
+    # assert that menu doesn't take up space when cli is exiting
+    assert height.min == 0
+    assert height.preferred == 1
+
+
+def test_select_menu_application_f10(cli):
+    feed_key(cli, Keys.F10)
+    assert cli.is_exiting
+
+
+@pytest.mark.parametrize('key', [Keys.Up, Keys.BackTab])
+def test_select_menu_application_up_backtab(cli, key):
+    feed_key(cli, key)
+    assert cli.application.menu_control.get_selection() == '3'
+
+
+@pytest.mark.parametrize('key', [Keys.Down, Keys.Tab])
+def test_select_menu_application_down_tab(cli, key):
+    feed_key(cli, key)
+    assert cli.application.menu_control.get_selection() == '1'
+
+
+def test_select_menu_application_accept(cli):
+    feed_key(cli, Keys.ControlJ)
+    # assert that no selection fails to accept
+    assert cli.return_value() is None
+    # move selection down then accept
+    feed_key(cli, Keys.Down)
+    feed_key(cli, Keys.ControlJ)
+    assert cli.return_value() == '1'
+
+
+def test_select_menu_application_any(cli):
+    buf = cli.application.buffers[DEFAULT_BUFFER]
+    # assert typing doesn't add text
+    feed_key(cli, Keys.Any, data=u'abc')
+    assert buf.text == ''
+    buf.document = Document(u'abc')
+    # assert backspace doesn't remove text
+    feed_key(cli, Keys.Backspace)
+    assert buf.text == 'abc'
+
+
+def test_select_menu_application_with_meta():
+    # test that selecting an option when theres info will render it
+    meta = {'opt': {'key': u'val'}}
+    app = SelectMenuApplication(u'prompt', [u'opt'], options_meta=meta)
+    cli = CommandLineInterface(application=app, eventloop=create_eventloop())
+    feed_key(cli, Keys.Down)
+    assert cli.application.buffers['INFO'].text == '{\n    "key": "val"\n}'

--- a/tests/integration/test_selectmenu.py
+++ b/tests/integration/test_selectmenu.py
@@ -64,7 +64,7 @@ def test_select_menu_application_accept(cli):
     # move selection down then accept
     feed_key(cli, Keys.Down)
     feed_key(cli, Keys.ControlJ)
-    assert cli.return_value() == '1'
+    assert cli.return_value() == ('1', 0)
 
 
 def test_select_menu_application_any(cli):
@@ -80,8 +80,23 @@ def test_select_menu_application_any(cli):
 
 def test_select_menu_application_with_meta():
     # test that selecting an option when theres info will render it
-    meta = {'opt': {'key': u'val'}}
+    meta = [{'key': u'val'}]
     app = SelectMenuApplication(u'prompt', [u'opt'], options_meta=meta)
     cli = CommandLineInterface(application=app, eventloop=create_eventloop())
     feed_key(cli, Keys.Down)
     assert cli.application.buffers['INFO'].text == '{\n    "key": "val"\n}'
+
+
+def test_select_menu_duplicate_option_with_meta():
+    options = [u'one', u'one']
+    meta = [{'key': u'1'}, {'key': u'2'}]
+    app = SelectMenuApplication(u'prompt', options, options_meta=meta)
+    cli = CommandLineInterface(application=app, eventloop=create_eventloop())
+    feed_key(cli, Keys.Down)
+    assert cli.application.buffers['INFO'].text == '{\n    "key": "1"\n}'
+    feed_key(cli, Keys.ControlJ)
+    assert cli.return_value() == ('one', 0)
+    feed_key(cli, Keys.Down)
+    assert cli.application.buffers['INFO'].text == '{\n    "key": "2"\n}'
+    feed_key(cli, Keys.ControlJ)
+    assert cli.return_value() == ('one', 1)

--- a/tests/unit/test_interaction.py
+++ b/tests/unit/test_interaction.py
@@ -79,7 +79,7 @@ def test_simple_select():
     prompt = mock.Mock()
     selector = SimpleSelect({}, 'one or two?', prompt)
     options = ['one', 'two']
-    prompt.return_value = options[1]
+    prompt.return_value = (options[1], 1)
     xformed = selector.execute(options)
     assert prompt.call_count == 1
     assert xformed == options[1]
@@ -92,7 +92,7 @@ def test_simple_select_with_path():
     model = {'Path': '[].a'}
     simple_selector = SimpleSelect(model, 'Promptingu', prompt)
     options = [{'a': '1', 'b': 'one'}, {'a': '2', 'b': 'two'}]
-    prompt.return_value = '2'
+    prompt.return_value = ('2', 1)
     xformed = simple_selector.execute(options)
     assert prompt.call_count == 1
     assert xformed == options[1]

--- a/tests/unit/test_selectmenu.py
+++ b/tests/unit/test_selectmenu.py
@@ -1,0 +1,108 @@
+import mock
+import pytest
+
+from prompt_toolkit.token import Token
+from awsshell.selectmenu import select_prompt, SelectMenuControl, \
+    SelectMenuApplication
+
+
+@pytest.fixture
+def menu_control():
+    options = [u'option 1', u'opt 2', u'option 3']
+    return SelectMenuControl(options)
+
+
+def test_select_prompt_creation():
+    # Test that the runner is given a select menu application
+    mock_runner = mock.Mock()
+    select_prompt(u'Prompt: ', [u'option'], runner=mock_runner)
+    assert mock_runner.call_count == 1
+    (args, kwargs) = mock_runner.call_args
+    assert isinstance(args[0], SelectMenuApplication)
+
+
+def test_select_menu_control_width(menu_control):
+    # Width should be longest option plus 2
+    dummy = mock.Mock()
+    assert menu_control.preferred_width(dummy, dummy) == len('option 1') + 2
+
+
+def test_select_menu_control_width_min():
+    # Width should be at least the minimum
+    menu_control = SelectMenuControl([u''])
+    dummy = mock.Mock()
+    assert menu_control.preferred_width(dummy, dummy) == menu_control.MIN_WIDTH
+
+
+def test_select_menu_control_height(menu_control):
+    # Height should be the number of options
+    dummy = mock.Mock()
+    height = menu_control.preferred_height(dummy, dummy, dummy, dummy)
+    assert height == 3
+
+
+def test_select_menu_get_selection(menu_control):
+    # Test that get selection returns the correct option
+    assert menu_control.get_selection() is None
+    menu_control.select_down()
+    assert menu_control.get_selection() == 'option 1'
+    menu_control.select_down()
+    assert menu_control.get_selection() == 'opt 2'
+    menu_control.select_up()
+    assert menu_control.get_selection() == 'option 1'
+
+
+def test_select_menu_get_select_down(menu_control):
+    # Test that select down wraps around correctly
+    assert menu_control.get_selection() is None
+    menu_control.select_down()
+    assert menu_control.get_selection() == 'option 1'
+    menu_control.select_down()
+    assert menu_control.get_selection() == 'opt 2'
+    menu_control.select_down()
+    assert menu_control.get_selection() == 'option 3'
+    menu_control.select_down()
+    assert menu_control.get_selection() == 'option 1'
+
+
+def test_select_menu_get_select_up(menu_control):
+    # Test that select up wraps around correctly
+    assert menu_control.get_selection() is None
+    menu_control.select_up()
+    assert menu_control.get_selection() == 'option 3'
+    menu_control.select_up()
+    assert menu_control.get_selection() == 'opt 2'
+    menu_control.select_up()
+    assert menu_control.get_selection() == 'option 1'
+    menu_control.select_up()
+    assert menu_control.get_selection() == 'option 3'
+
+
+def test_select_menu_inserts_text(menu_control):
+    # Test that selection will modify the current buffer if given an event
+    mock_event = mock.Mock()
+    menu_control.select_down(event=mock_event)
+    assert mock_event.current_buffer.document.text == 'option 1'
+    menu_control.select_up(event=mock_event)
+    assert mock_event.current_buffer.document.text == 'option 3'
+
+
+def test_select_menu_create_content(menu_control):
+    dummy = mock.Mock()
+    ui_content = menu_control.create_content(dummy, dummy, dummy)
+    # assert the generated get line is callable
+    assert callable(ui_content.get_line)
+    get_line = ui_content.get_line
+    token = Token.Menu.Completions
+    # assert the correct lines and tokens are generated
+    assert [(token.Completion, ' option 1   ')] == get_line(0)
+    assert [(token.Completion, ' opt 2      ')] == get_line(1)
+    assert [(token.Completion, ' option 3   ')] == get_line(2)
+    menu_control.select_down()
+    assert [(token.Completion.Current, ' option 1   ')] == get_line(0)
+    assert [(token.Completion, ' opt 2      ')] == get_line(1)
+    assert [(token.Completion, ' option 3   ')] == get_line(2)
+    menu_control.select_down()
+    assert [(token.Completion, ' option 1   ')] == get_line(0)
+    assert [(token.Completion.Current, ' opt 2      ')] == get_line(1)
+    assert [(token.Completion, ' option 3   ')] == get_line(2)


### PR DESCRIPTION
An implementation of a selection menu using prompt toolkit. This is very similar to the original prompt provided by prompt toolkit but has a few tweaks that are not possible through the parameters exposed by the library itself. Selecting an option from a set of options is a different enough use case that the following features were required: forcing the selection of one of the options, not allowing the editing of options once selected, and showing the prompt without any input from the user. Additionally, it allows me to modify the layout to begin adding a meta information window similar to the shell's docs. 

@JordonPhillips @kyleknap @jamesls 