### PR TITLE
Fix integrations tests to work with prompt_toolkit 1.0.4

### DIFF
--- a/tests/integration/test_selectmenu.py
+++ b/tests/integration/test_selectmenu.py
@@ -3,6 +3,8 @@ import pytest
 
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.token import Token
+from prompt_toolkit.input import PipeInput
+from prompt_toolkit.output import DummyOutput
 from prompt_toolkit.document import Document
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.shortcuts import create_eventloop
@@ -13,9 +15,31 @@ from awsshell.selectmenu import SelectMenuApplication
 
 
 @pytest.fixture
-def cli():
+def make_cli():
     app = SelectMenuApplication(u'prompt', [u'1', u'2', u'3'])
-    return CommandLineInterface(application=app, eventloop=create_eventloop())
+
+    def generator(app=app, cli_input=None, output=DummyOutput()):
+        return CommandLineInterface(
+                application=app,
+                input=cli_input,
+                output=output,
+                eventloop=create_eventloop()
+        )
+    return generator
+
+
+@pytest.yield_fixture
+def pipe_input():
+    pipe = PipeInput()
+    try:
+        yield pipe
+    finally:
+        pipe.close()
+
+
+@pytest.yield_fixture
+def cli(pipe_input, make_cli):
+    yield make_cli(cli_input=pipe_input)
 
 
 def feed_key(cli, key, data=u''):
@@ -78,20 +102,20 @@ def test_select_menu_application_any(cli):
     assert buf.text == 'abc'
 
 
-def test_select_menu_application_with_meta():
+def test_select_menu_application_with_meta(pipe_input, make_cli):
     # test that selecting an option when theres info will render it
     meta = [{'key': u'val'}]
     app = SelectMenuApplication(u'prompt', [u'opt'], options_meta=meta)
-    cli = CommandLineInterface(application=app, eventloop=create_eventloop())
+    cli = make_cli(app=app, cli_input=pipe_input)
     feed_key(cli, Keys.Down)
     assert cli.application.buffers['INFO'].text == '{\n    "key": "val"\n}'
 
 
-def test_select_menu_duplicate_option_with_meta():
+def test_select_menu_duplicate_option_with_meta(pipe_input, make_cli):
     options = [u'one', u'one']
     meta = [{'key': u'1'}, {'key': u'2'}]
     app = SelectMenuApplication(u'prompt', options, options_meta=meta)
-    cli = CommandLineInterface(application=app, eventloop=create_eventloop())
+    cli = make_cli(app=app, cli_input=pipe_input)
     feed_key(cli, Keys.Down)
     assert cli.application.buffers['INFO'].text == '{\n    "key": "1"\n}'
     feed_key(cli, Keys.ControlJ)


### PR DESCRIPTION
`prompt_toolkit` updated to version 1.0.4 which adds an assertion that the `input`/`output` given to a `CommandLineInterface` be a TTY. This assertion happens at object instantiation which affects the way we do some of our integration tests. 

We currently have some tests in `integration\test_keys.py` and `integration\test_selectmenu.py` that instantiate CLIs and simulate key presses to them by calling `feed` and `process_keys`. This is used to test that key bindings are properly registered and have the correct results on the state of the CLI. However, the CLI's `run` method is not called, meaning that the actual input and output streams seem to not be used. This is what allowed the tests to function previously. Now that there are assertions to verify that the `input` and `output` are TTYs at instantiation the tests fail immediately. This can be fixed by passing `Input` and `Output` objects that don't rely on `stdin` and `stdout`.

This is what the fix would like. For `test_keys.py` we would next to change the `AWSShell` to pass a pluggable `input` and `output` when it creates it's CLI.

@JordonPhillips @jamesls 