### PR TITLE
Stateful commands + small cache and performance changes

### DIFF
--- a/awsshell/autocomplete.py
+++ b/awsshell/autocomplete.py
@@ -24,6 +24,7 @@ class AWSCLIModelCompleter(object):
         # This will get populated as a command is completed.
         self.cmd_path = [self._current_name]
         self.match_fuzzy = match_fuzzy
+        self.context = []
         self._cache_all_args = []
 
     @property
@@ -43,6 +44,15 @@ class AWSCLIModelCompleter(object):
         self._last_position = 0
         self.last_option = ''
         self.cmd_path = [self._current_name]
+        for context in self.context:
+            next_command = self._current['children'].get(context)
+            if not next_command:
+                self.context.remove(context)
+                self.reset()
+                return
+            self._current = next_command
+            self._current_name = context
+            self.cmd_path.append(self._current_name)
         self._cache_all_args = []
 
     def autocomplete(self, line):

--- a/awsshell/autocomplete.py
+++ b/awsshell/autocomplete.py
@@ -69,9 +69,10 @@ class AWSCLIModelCompleter(object):
             return self._handle_backspace()
         elif not line:
             return []
-        elif self._last_position == 0 and current_length > 2:
-            return self._complete_from_full_parse()
-        elif current_length != self._last_position + 1 and '--' in line:
+        elif (self._last_position == 0 and
+                current_length > 2) or (
+                current_length != self._last_position + 1
+                and '--' in line):
             return self._complete_from_full_parse()
 
         # This position is important.  We only update the _last_position

--- a/tests/unit/test_autocomplete.py
+++ b/tests/unit/test_autocomplete.py
@@ -380,3 +380,31 @@ def test_global_arg_metadata_property(index_data):
     }
     completer = AWSCLIModelCompleter(index_data)
     assert '--global1' in completer.global_arg_metadata
+
+def test_add_context_changes_context(index_data):
+    index_data['aws']['commands'] = ['ec2']
+    index_data['aws']['children'] = {
+        'ec2': {
+            'commands': ['create-tags'],
+            'argument_metadata': {},
+            'arguments': [],
+            'children': {
+                'create-tags': {
+                    'commands': [],
+                    'argument_metadata': {
+                        '--resources': {'example': '', 'minidoc': 'foo'},
+                    },
+                    'arguments': ['--resources'],
+                    'children': {},
+                }
+            }
+        }
+    }
+    completer = AWSCLIModelCompleter(index_data)
+    completer.reset()
+    completer.autocomplete('c')
+    assert completer.autocomplete('c') == ['ec2']
+    completer.context = ['ec2']
+    completer.reset()
+    completer.autocomplete('c')
+    assert completer.autocomplete('c') == ['create-tags']


### PR DESCRIPTION
# Stateful Commands

`@` can be used to add a context to the prompt. e.g. `@ec2` will implicitly prefix all commands with ec2. `exit` will remove the most recently added context.  See [issue](https://github.com/awslabs/aws-shell/issues/87).
# Cache and Performance

It used to be that every time the user did a tab completion, the autocompleter would have to do a full parse of the entire line. I made some changes on the condition for full parses such that only tab completions with arguments do a full parse.

Also, all_args are cached while there is no change in context.
