### PR TITLE
Fixed integration tests for key bindings.

### DIFF
--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -220,7 +220,8 @@ class AWSShell(object):
 
     """
 
-    def __init__(self, completer, model_completer, docs):
+    def __init__(self, completer, model_completer, docs,
+                 input=None, output=None):
         self.completer = completer
         self.model_completer = model_completer
         self.history = InMemoryHistory()
@@ -233,6 +234,8 @@ class AWSShell(object):
         self._dot_cmd = DotCommandHandler()
         self._env = os.environ.copy()
         self._profile = None
+        self._input = input
+        self._output = output
 
         # These attrs come from the config file.
         self.config_obj = None
@@ -456,7 +459,8 @@ class AWSShell(object):
         app = self.create_application(self.completer,
                                       self.file_history,
                                       display_completions_in_columns)
-        cli = CommandLineInterface(application=app, eventloop=loop)
+        cli = CommandLineInterface(application=app, eventloop=loop,
+                                   input=self._input, output=self._output)
         return cli
 
     @property

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -11,11 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import mock
-import sys
 
+from prompt_toolkit.input import PipeInput
+from prompt_toolkit.output import DummyOutput
 from prompt_toolkit.key_binding.input_processor import KeyPress
 from prompt_toolkit.keys import Keys
-from prompt_toolkit.interface import CommandLineInterface
 
 from tests.compat import unittest
 from awsshell.app import AWSShell, InputInterrupt
@@ -24,8 +24,14 @@ from awsshell.app import AWSShell, InputInterrupt
 class KeysTest(unittest.TestCase):
 
     def setUp(self):
-        self.aws_shell = AWSShell(None, mock.Mock(), mock.Mock())
+        self.input = PipeInput()
+        output = DummyOutput()
+        self.aws_shell = AWSShell(None, mock.Mock(), mock.Mock(),
+                                  input=self.input, output=output)
         self.processor = self.aws_shell.cli.input_processor
+
+    def tearDown(self):
+        self.input.close()
 
     def feed_key(self, key):
         self.processor.feed(KeyPress(key, u''))


### PR DESCRIPTION
Previously the integration tests for the `CommandLineInterface` object relied on the default `Input` and `Output` objects instantiated which were based on `stdin` and `stdout`. `prompt_tookit` updated to version 1.0.4 which adds checks that the `Input` and `Output` objects are TTYs, which doesn't hold true when the tests are run as IO is redirected. Changed the IO objects to be the same that `prompt_toolkit` uses to test CLI objects.

@JordonPhillips @jamesls 