### PR TITLE
Editing mode fix and documentation scrolling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,7 +180,8 @@ Inline Documentation
 The aws-shell will automatically pull up documentation as you type commands.
 It will show inline documentation for CLI options.  There is also a separate
 documentation panel that will show documentation for the current command or
-option you are typing.
+option you are typing. Pressing F9 or clicking this panel will focus it
+allowing the use of your keybindings or scroll wheel to navigate the docs.
 
 .. image:: https://cloud.githubusercontent.com/assets/368057/11823320/36ae9b04-a328-11e5-9661-81abfc0afe5a.png
 
@@ -211,6 +212,7 @@ The aws-shell has a bottom toolbar that provides several options:
 * ``F3`` toggles between VI and Emacs key bindings
 * ``F4`` toggles between single and multi column auto completions
 * ``F5`` shows and hides the help documentation pane
+* ``F9`` toggles focus between the cli and documentation pane
 * ``F10`` or ``Ctrl-D`` exits the aws-shell
 
 As you toggle options in the toolbar, your preferences are persisted

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -17,6 +17,7 @@ from prompt_toolkit.interface import CommandLineInterface, Application
 from prompt_toolkit.interface import AbortAction, AcceptAction
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.history import InMemoryHistory, FileHistory
+from prompt_toolkit.enums import EditingMode
 
 from awsshell.ui import create_default_layout
 from awsshell.config import Config
@@ -417,7 +418,13 @@ class AWSShell(object):
             'clidocs': Buffer(read_only=True)
         }
 
+        if self.enable_vi_bindings:
+            editing_mode = EditingMode.VI
+        else:
+            editing_mode = EditingMode.EMACS
+
         return Application(
+            editing_mode=editing_mode,
             layout=self.create_layout(display_completions_in_columns, toolbar),
             mouse_support=False,
             style=style_factory.style,

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -426,7 +426,7 @@ class AWSShell(object):
         return Application(
             editing_mode=editing_mode,
             layout=self.create_layout(display_completions_in_columns, toolbar),
-            mouse_support=False,
+            mouse_support=True,
             style=style_factory.style,
             buffers=buffers,
             buffer=self.create_buffer(completer, history),
@@ -454,8 +454,18 @@ class AWSShell(object):
                 self.current_docs = self._docs.extract_description(key_name)
         else:
             self.current_docs = u''
+
+        position = cli.buffers['clidocs'].document.cursor_position
+        # if the docs to be displayed have changed, reset position to 0
+        if cli.buffers['clidocs'].text != self.current_docs:
+            position = 0
+
         cli.buffers['clidocs'].reset(
-            initial_document=Document(self.current_docs, cursor_position=0))
+            initial_document=Document(
+                self.current_docs,
+                cursor_position=position
+            )
+        )
         cli.request_redraw()
 
     def create_cli_interface(self, display_completions_in_columns):

--- a/awsshell/keys.py
+++ b/awsshell/keys.py
@@ -97,7 +97,6 @@ class KeyManager(object):
             enable_abort_and_exit_bindings=True,
             enable_system_bindings=True,
             enable_auto_suggest_bindings=True,
-            enable_vi_mode=get_enable_vi_bindings(),
             enable_open_in_editor=False)
 
         @self.manager.registry.add_binding(Keys.F2)
@@ -144,6 +143,20 @@ class KeyManager(object):
             """
             set_show_help(not get_show_help())
             stop_input_and_refresh_cli()
+
+        @self.manager.registry.add_binding(Keys.F9)
+        def handle_f9(event):
+            """Switch between the default and docs buffers.
+
+            :type event: :class:`prompt_toolkit.Event`
+            :param event: Contains info about the event, namely the cli
+                which is used to changing which buffer is focused.
+
+            """
+            if event.cli.current_buffer_name == u'clidocs':
+                event.cli.focus(u'DEFAULT_BUFFER')
+            else:
+                event.cli.focus(u'clidocs')
 
         @self.manager.registry.add_binding(Keys.F10)
         def handle_f10(event):

--- a/awsshell/toolbar.py
+++ b/awsshell/toolbar.py
@@ -54,11 +54,11 @@ class Toolbar(object):
         assert callable(get_show_completion_columns)
         assert callable(get_show_help)
 
-        def get_toolbar_items(_):
+        def get_toolbar_items(cli):
             """Return the toolbar items.
 
-            :type _: :class:`prompt_toolkit.Cli`
-            :param _: (Unused)
+            :type cli: :class:`prompt_toolkit.Cli`
+            :param cli: The command line interface from prompt_toolkit
 
             :rtype: list
             :return: A list of (pygments.Token.Toolbar, str).
@@ -87,6 +87,10 @@ class Toolbar(object):
             else:
                 show_help_token = Token.Toolbar.Off
                 show_help_cfg = 'OFF'
+            if cli.current_buffer_name == 'DEFAULT_BUFFER':
+                show_buffer_name = 'cli'
+            else:
+                show_buffer_name = 'doc'
             return [
                 (match_fuzzy_token,
                  ' [F2] Fuzzy: {0} '.format(match_fuzzy_cfg)),
@@ -96,6 +100,8 @@ class Toolbar(object):
                  ' [F4] {0} Column '.format(show_columns_cfg)),
                 (show_help_token,
                  ' [F5] Help: {0} '.format(show_help_cfg)),
+                (Token.Toolbar,
+                 ' [F9] Focus: {0} '.format(show_buffer_name)),
                 (Token.Toolbar,
                  ' [F10] Exit ')
             ]

--- a/awsshell/ui.py
+++ b/awsshell/ui.py
@@ -155,7 +155,9 @@ def create_default_layout(app, message='',
                         lexer=lexer,
                         # Enable preview_search, we want to have immediate
                         # feedback in reverse-i-search mode.
-                        preview_search=Always()),
+                        preview_search=Always(),
+                        focus_on_click=True,
+                    ),
                     get_height=get_height,
                 ),
                 [
@@ -179,7 +181,8 @@ def create_default_layout(app, message='',
         ConditionalContainer(
             content=Window(
                 BufferControl(
-                    buffer_name='clidocs',
+                    focus_on_click=True,
+                    buffer_name=u'clidocs',
                 ),
                 height=LayoutDimension(max=15)),
             filter=HasDocumentation(app) & ~IsDone(),

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -46,20 +46,20 @@ class KeysTest(unittest.TestCase):
         enable_vi_bindings = self.aws_shell.enable_vi_bindings
         with self.assertRaises(InputInterrupt):
             self.feed_key(Keys.F3)
-            assert enable_vi_bindings != self.aws_shell.enable_vi_bindings
+        assert enable_vi_bindings != self.aws_shell.enable_vi_bindings
 
     def test_F4(self):
         show_completion_columns = self.aws_shell.show_completion_columns
         with self.assertRaises(InputInterrupt):
             self.feed_key(Keys.F4)
-            assert show_completion_columns != \
-                self.aws_shell.show_completion_columns
+        assert show_completion_columns != \
+            self.aws_shell.show_completion_columns
 
     def test_F5(self):
         show_help = self.aws_shell.show_help
         with self.assertRaises(InputInterrupt):
             self.feed_key(Keys.F5)
-            assert show_help != self.aws_shell.show_help
+        assert show_help != self.aws_shell.show_help
 
     def test_F10(self):
         self.feed_key(Keys.F10)

--- a/tests/integration/test_keys.py
+++ b/tests/integration/test_keys.py
@@ -61,6 +61,11 @@ class KeysTest(unittest.TestCase):
             self.feed_key(Keys.F5)
         assert show_help != self.aws_shell.show_help
 
+    def test_F9(self):
+        assert self.aws_shell.cli.current_buffer_name == u'DEFAULT_BUFFER'
+        self.feed_key(Keys.F9)
+        assert self.aws_shell.cli.current_buffer_name == u'clidocs'
+
     def test_F10(self):
         self.feed_key(Keys.F10)
         assert self.aws_shell.cli.is_exiting

--- a/tests/unit/test_toolbar.py
+++ b/tests/unit/test_toolbar.py
@@ -22,6 +22,7 @@ class ToolbarTest(unittest.TestCase):
 
     def setUp(self):
         self.aws_shell = AWSShell(mock.Mock(), mock.Mock(), mock.Mock())
+        self.cli = mock.Mock()
         self.toolbar = Toolbar(
             lambda: self.aws_shell.model_completer.match_fuzzy,
             lambda: self.aws_shell.enable_vi_bindings,
@@ -38,18 +39,21 @@ class ToolbarTest(unittest.TestCase):
             (Token.Toolbar.On, ' [F3] Keys: Vi '),
             (Token.Toolbar.On, ' [F4] Multi Column '),
             (Token.Toolbar.On, ' [F5] Help: ON '),
+            (Token.Toolbar, ' [F9] Focus: doc '),
             (Token.Toolbar, ' [F10] Exit ')]
-        assert expected == self.toolbar.handler(None)
+        assert expected == self.toolbar.handler(self.cli)
 
     def test_toolbar_off(self):
         self.aws_shell.model_completer.match_fuzzy = False
         self.aws_shell.enable_vi_bindings = False
         self.aws_shell.show_completion_columns = False
         self.aws_shell.show_help = False
+        self.cli.current_buffer_name = 'DEFAULT_BUFFER'
         expected = [
             (Token.Toolbar.Off, ' [F2] Fuzzy: OFF '),
             (Token.Toolbar.On, ' [F3] Keys: Emacs '),
             (Token.Toolbar.On, ' [F4] Single Column '),
             (Token.Toolbar.Off, ' [F5] Help: OFF '),
+            (Token.Toolbar, ' [F9] Focus: cli '),
             (Token.Toolbar, ' [F10] Exit ')]
-        assert expected == self.toolbar.handler(None)
+        assert expected == self.toolbar.handler(self.cli)


### PR DESCRIPTION
Prompt toolkit deprecated setting the editing mode via the `enable_vi_mode` kwarg on key manager creation. The editing mode is now directly passed to the `Application` instantiation based on the bool instead. 

Additionally, I've enabled mouse support to switch between the default and docs buffers on click and allowed for scrolling in the docs buffer. I've also added a keybinding on `F9` to switch between the buffers. I'm not sure which key is best to toggle back and forth, perhaps there are some standards that vim/emacs have that we could bind this to instead.
Fix for #74 

**Note**: Enabling mouse support in prompt_toolkit seems to have the side effect that the terminals built in text highlighting/selection no longer works. I verified this behavior by looking at pyvim which also does the same thing. While switching between the buffers with mouse clicks and scrolling the docs with the scroll wheel is very natural, losing text selection might not be the best customer experience. 

@jamesls @JordonPhillips 
