### PR TITLE
Stage History

### DIFF
--- a/awsshell/interaction.py
+++ b/awsshell/interaction.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 
 from prompt_toolkit import prompt
 from prompt_toolkit.contrib.completers import PathCompleter
-from awsshell.utils import FSLayer
+from awsshell.utils import FSLayer, FileReadError
 from awsshell.selectmenu import select_prompt
 
 
@@ -52,7 +52,10 @@ class FilePrompt(Interaction):
 
     def execute(self, data, fslayer=FSLayer()):
         path = self.get_path()
-        return fslayer.file_contents(path)
+        try:
+            return fslayer.file_contents(path)
+        except FileReadError:
+            raise InteractionException('Error reading file: %s' % path)
 
 
 class SimpleSelect(Interaction):

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -35,7 +35,7 @@ def stage_error_handler(error, stages, confirm=confirm, prompt=select_prompt):
         else:
             raise KeyboardInterrupt()
     else:
-        raise error
+        return None
 
 
 class WizardException(Exception):
@@ -177,7 +177,10 @@ class Wizard(object):
                 current_stage = stage.get_next_stage()
             except Exception as err:
                 stages = [s.name for (s, _) in self._stage_history]
-                (stage, index) = self._error_handler(err, stages)
+                recovery = self._error_handler(err, stages)
+                if recovery is None:
+                    raise
+                (stage, index) = recovery
                 self._pop_stages(index)
                 current_stage = stage
 

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -111,6 +111,7 @@ class Wizard(object):
         self.env = environment
         self.start_stage = start_stage
         self._load_stages(stages)
+        self._stage_history = []
 
     def _load_stages(self, stages):
         """Load the stages dictionary from the given list of stage objects.
@@ -123,11 +124,11 @@ class Wizard(object):
             self.stages[stage.name] = stage
 
     def _select_stage_prompt(self):
-        stages = [s.name for (s, _) in self.env._stage_history]
+        stages = [s.name for (s, _) in self._stage_history]
         selector = SimpleSelect({}, 'Select a Stage to return to: ')
-        current_stage = selector.execute(stages)
-        self.env.pop_stages(stages.index(current_stage))
-        return current_stage
+        selected_stage = selector.execute(stages)
+        self._pop_stages(stages.index(selected_stage))
+        return selected_stage
 
     def execute(self):
         """Run the wizard. Execute Stages until a final stage is reached.
@@ -140,6 +141,7 @@ class Wizard(object):
             if not stage:
                 raise WizardException('Stage not found: %s' % current_stage)
             try:
+                self._push_stage(stage)
                 stage.execute()
                 current_stage = stage.get_next_stage()
             except EOFError:
@@ -147,10 +149,17 @@ class Wizard(object):
             except Exception as e:
                 sys.stdout.write('{0}\n'.format(e))
                 sys.stdout.flush()
-                if confirm('Select a previous stage? (y/n) '):
+                if confirm(u'Select a previous stage? (y/n) '):
                     current_stage = self._select_stage_prompt()
                 else:
                     raise
+
+    def _push_stage(self, stage):
+        self._stage_history.append((stage, copy.deepcopy(self.env)))
+
+    def _pop_stages(self, stage_index):
+        self.env.update(self._stage_history[stage_index][1])
+        self._stage_history = self._stage_history[:stage_index]
 
 
 class Stage(object):
@@ -266,7 +275,6 @@ class Stage(object):
         2) Perform Interaction on retrieved data.
         3) Perform Resolution to store data in the environment.
         """
-        self._env.push_stage(self)
         retrieved_options = self._handle_retrieval()
         selected_data = self._handle_interaction(retrieved_options)
         self._handle_resolution(selected_data)
@@ -275,12 +283,15 @@ class Stage(object):
 class Environment(object):
     """Store vars into a dict and retrives them with JMESPath queries."""
 
-    def __init__(self, stage_history=[]):
+    def __init__(self):
         self._variables = {}
-        self._stage_history = stage_history
 
     def __str__(self):
         return json.dumps(self._variables, indent=4, sort_keys=True)
+
+    def update(self, environment):
+        assert isinstance(environment, Environment)
+        self._variables = environment._variables
 
     def store(self, key, val):
         """Store a variable under the given key.
@@ -318,10 +329,3 @@ class Environment(object):
         for key in keys:
             resolved_dict[key] = self.retrieve(keys[key])
         return resolved_dict
-
-    def push_stage(self, stage):
-        self._stage_history.append((stage, copy.deepcopy(self._variables)))
-
-    def pop_stages(self, stage_index):
-        self._variables = self._stage_history[stage_index][1]
-        self._stage_history = self._stage_history[:stage_index]

--- a/tests/unit/test_interaction.py
+++ b/tests/unit/test_interaction.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from awsshell.utils import InMemoryFSLayer, FileReadError
+from awsshell.utils import InMemoryFSLayer
 from awsshell.interaction import InteractionLoader, InteractionException
 from awsshell.interaction import SimpleSelect, SimplePrompt, FilePrompt
 
@@ -70,7 +70,7 @@ def test_file_prompt_nonexistent_file(temp_fs):
     prompt = mock.Mock()
     file_prompt = FilePrompt({}, 'msg', prompt)
     prompt.return_value = '/some/notafile'
-    with pytest.raises(FileReadError):
+    with pytest.raises(InteractionException):
         file_prompt.execute({}, fslayer=temp_fs)
 
 

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -299,5 +299,5 @@ def test_stage_exception_handler_other(error_class):
     prompt = mock.Mock()
     confirm = mock.Mock()
     err = error_class()
-    with pytest.raises(error_class):
-        stage_error_handler(err, ['stage'], confirm=confirm, prompt=prompt)
+    res = stage_error_handler(err, ['stage'], confirm=confirm, prompt=prompt)
+    assert res is None

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -1,5 +1,9 @@
 import mock
 import pytest
+from awsshell.utils import FileReadError
+from awsshell.wizard import stage_error_handler
+from awsshell.interaction import InteractionException
+from botocore.exceptions import ClientError, BotoCoreError
 from awsshell.wizard import Environment, WizardLoader, WizardException
 
 
@@ -174,6 +178,26 @@ def test_basic_full_execution(wizard_spec, loader):
     assert str(wizard.env) == display_str
 
 
+def test_basic_full_execution_error(wizard_spec):
+    # Test that the wizard can handle exceptions in stage execution
+    session = mock.Mock()
+    error_handler = mock.Mock()
+    error_handler.return_value = ('TestStage', 0)
+    loader = WizardLoader(session, error_handler=error_handler)
+    wizard_spec['Stages'][0]['NextStage'] = \
+        {'Type': 'Name', 'Name': 'StageTwo'}
+    wizard_spec['Stages'][0]['Resolution']['Path'] = '[0].Stage'
+    stage_three = {'Name': 'StageThree', 'Prompt': 'Text'}
+    wizard = loader.create_wizard(wizard_spec)
+    # force an exception once, let it recover, re-run
+    error = WizardException()
+    wizard.stages['StageTwo'].execute = mock.Mock(side_effect=[error, {}])
+    wizard.execute()
+    # assert error handler was called
+    assert error_handler.call_count == 1
+    assert wizard.stages['StageTwo'].execute.call_count == 2
+
+
 def test_missing_start_stage(wizard_spec, loader):
     # Test that the loader throws an error if the spec is missing start stage
     wizard_spec['StartStage'] = None
@@ -233,3 +257,47 @@ def test_wizard_basic_interaction(wizard_spec):
     create = i_loader.create
     create.assert_called_once_with(inter, 'Prompting')
     create.return_value.execute.assert_called_once_with(data)
+
+
+exceptions = [
+    BotoCoreError(),
+    WizardException('error'),
+    InteractionException('error'),
+    ClientError({'Error': {}}, 'Operation')
+]
+
+
+@pytest.mark.parametrize('err', exceptions)
+@pytest.mark.parametrize('accept_confirm', [True, False])
+def test_stage_exception_handler(err, accept_confirm):
+    # Verify known exceptions will confirm retry and prompt
+    confirm = mock.Mock()
+    confirm.return_value = accept_confirm
+    prompt = mock.Mock()
+    stages = ['stage1', 'stage2']
+    try:
+        stage_error_handler(err, stages, confirm=confirm, prompt=prompt)
+        assert accept_confirm
+        assert prompt.call_count == 1
+    except KeyboardInterrupt:
+        assert not accept_confirm
+        assert prompt.call_count == 0
+
+
+def test_stage_exception_handler_eof():
+    # Verify EOFError directly calls the prompt
+    prompt = mock.Mock()
+    confirm = mock.Mock()
+    stage_error_handler(EOFError(), ['stage'], confirm=confirm, prompt=prompt)
+    assert confirm.call_count == 0
+    assert prompt.call_count == 1
+
+
+@pytest.mark.parametrize('error_class', [FileReadError, Exception])
+def test_stage_exception_handler_other(error_class):
+    # Verify other exceptions are re-raised
+    prompt = mock.Mock()
+    confirm = mock.Mock()
+    err = error_class()
+    with pytest.raises(error_class):
+        stage_error_handler(err, ['stage'], confirm=confirm, prompt=prompt)


### PR DESCRIPTION
Implemented stage history, error recovery and related unit tests.

I would like the `raise error` to be just a bare raise to preserve the stack trace but I fail linting if I do that. I tried using six.reraise instead but this had some issues in unit tests.

cc @JordonPhillips 