### PR TITLE
Force unicode before interaction

### DIFF
--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -8,6 +8,7 @@ from botocore import xform_name
 from botocore.exceptions import BotoCoreError, ClientError
 
 from awsshell.resource import index
+from awsshell.utils import force_unicode
 from awsshell.selectmenu import select_prompt
 from awsshell.interaction import InteractionLoader, InteractionException
 
@@ -275,13 +276,14 @@ class Stage(object):
         return data
 
     def _handle_interaction(self, data):
+
         # if no interaction step, just forward data
         if self.interaction is None:
             return data
         else:
             creator = self._interaction_loader.create
             interaction = creator(self.interaction, self.prompt)
-            return interaction.execute(data)
+            return interaction.execute(force_unicode(data))
 
     def _handle_resolution(self, data):
         if self.resolution:


### PR DESCRIPTION
Prompt toolkit requires that the strings given to it are unicode. Data given to interactions can come from arbitrary sources (service calls) so there must be some mechanism in place ensuring that all strings given to prompt toolkit are of `six.text_type`. This function will recursively search lists and dicts for strings and encode any non-unicode strings as unicode. This is not ideal but is necessary to move forward.

@JordonPhillips @kyleknap 