### PR TITLE
Fuzzy Select Interaction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 requires = [
     'awscli>=1.10.30,<2.0.0',
-    'prompt-toolkit>=1.0.0,<1.1.0',
+    'prompt-toolkit>=1.0.6,<1.1.0',
     'boto3>=1.2.1,<2.0.0',
     'configobj>=5.0.6,<6.0.0',
     'Pygments>=2.1.3,<3.0.0',


### PR DESCRIPTION
A fuzzy select interaction to address some of the feedback Dave had at the wizards planning meeting. This interaction will allow the user to type which will apply the fuzzy search algorithm to filter the list. It will also validate that the input is from the list and reject all others. This is using the `SentenceValidator` class which was failing tests on python 2.6 due to having a set comprehension. I've made a pull request upstream which has been merged as of `prompt_toolkit` v1.0.6. As such the minimum version will be bumped to v1.0.6

@JordonPhillips @jamesls 

### Displaying all options
<img width="681" alt="screen shot 2016-08-15 at 17 11 19" src="https://cloud.githubusercontent.com/assets/1935727/17683853/6ff382fa-630b-11e6-9ac7-9d20549bffc6.png">
### Filtering the list by typing
<img width="691" alt="screen shot 2016-08-15 at 17 11 43" src="https://cloud.githubusercontent.com/assets/1935727/17683855/72580c00-630b-11e6-8934-8e9836b51979.png">
### Validating input is part of the list
<img width="690" alt="screen shot 2016-08-15 at 17 12 02" src="https://cloud.githubusercontent.com/assets/1935727/17683858/73a4cba2-630b-11e6-9cc3-cef73b985309.png">
