### PR TITLE
Info Select & Rendering responses JSON

### DIFF
--- a/awsshell/selectmenu.py
+++ b/awsshell/selectmenu.py
@@ -1,4 +1,3 @@
-import json
 from pygments.lexers import find_lexer_class
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.token import Token
@@ -21,6 +20,7 @@ from prompt_toolkit.layout.controls import UIControl, UIContent, FillControl
 from prompt_toolkit.layout import Window, HSplit, FloatContainer, Float
 from prompt_toolkit.layout.containers import ScrollOffsets, \
     ConditionalContainer
+from awsshell.utils import format_json
 
 """An implementation of a selection menu using prompt toolkit.
 
@@ -261,8 +261,7 @@ class SelectMenuApplication(Application):
             def selection_changed(cli):
                 index = self.menu_control.get_index()
                 info = options_meta[index]
-                formatted_info = json.dumps(info, indent=4, sort_keys=True,
-                                            ensure_ascii=False)
+                formatted_info = format_json(info)
                 buffers['INFO'].text = formatted_info
             default_buf.on_text_changed += selection_changed
 

--- a/awsshell/utils.py
+++ b/awsshell/utils.py
@@ -6,9 +6,11 @@ import contextlib
 import tempfile
 import uuid
 import logging
+import json
 
 import awscli
 
+from awscli.utils import json_encoder
 from awsshell.compat import HTMLParser
 
 
@@ -142,3 +144,8 @@ def force_unicode(obj, encoding='utf8'):
         if not isinstance(obj, six.text_type):
             obj = _attempt_decode(obj, encoding)
     return obj
+
+
+def format_json(response):
+    return json.dumps(response, indent=4, default=json_encoder,
+                      ensure_ascii=False, sort_keys=True)

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -1,6 +1,5 @@
 import sys
 import copy
-import json
 import logging
 import jmespath
 
@@ -9,7 +8,7 @@ from botocore import xform_name
 from botocore.exceptions import BotoCoreError, ClientError
 
 from awsshell.resource import index
-from awsshell.utils import force_unicode
+from awsshell.utils import force_unicode, format_json
 from awsshell.selectmenu import select_prompt
 from awsshell.interaction import InteractionLoader, InteractionException
 
@@ -348,7 +347,7 @@ class Environment(object):
         self._variables = {}
 
     def __str__(self):
-        return json.dumps(self._variables, indent=4, sort_keys=True)
+        return format_json(self._variables)
 
     def update(self, environment):
         assert isinstance(environment, Environment)

--- a/tests/unit/test_interaction.py
+++ b/tests/unit/test_interaction.py
@@ -6,7 +6,7 @@ from prompt_toolkit.buffer import Document
 from prompt_toolkit.contrib.validators.base import Validator, ValidationError
 from awsshell.interaction import InteractionLoader, InteractionException
 from awsshell.interaction import SimpleSelect, SimplePrompt, FilePrompt
-from awsshell.interaction import FuzzyCompleter, FuzzySelect
+from awsshell.interaction import FuzzyCompleter, FuzzySelect, InfoSelect
 
 
 @pytest.fixture
@@ -88,12 +88,13 @@ def test_simple_select():
     assert xformed == options[1]
 
 
-def test_simple_select_with_path():
+@pytest.mark.parametrize('selector', [SimpleSelect, InfoSelect])
+def test_simple_select_with_path(selector):
     # Verify that SimpleSelect calls prompt and it returns the corresponding
     # item derived from the path.
     prompt = mock.Mock()
     model = {'Path': '[].a'}
-    simple_selector = SimpleSelect(model, 'Promptingu', prompt)
+    simple_selector = selector(model, 'Promptingu', prompt)
     options = [{'a': '1', 'b': 'one'}, {'a': '2', 'b': 'two'}]
     prompt.return_value = ('2', 1)
     xformed = simple_selector.execute(options)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 from tests import unittest
 import os
 import tempfile
+import datetime
 import shutil
 import six
 import pytest
@@ -10,6 +11,7 @@ from awsshell.utils import InMemoryFSLayer
 from awsshell.utils import FileReadError
 from awsshell.utils import temporary_file
 from awsshell.utils import force_unicode
+from awsshell.utils import format_json
 
 
 class TestFSLayer(unittest.TestCase):
@@ -127,3 +129,8 @@ def test_force_unicode_recursion():
     assert isinstance(clean_obj['b']['str'], six.text_type)
     assert clean_obj['c'] is obj['c']
     assert obj == clean_obj
+
+
+def test_format_json():
+    data = {'Key': datetime.datetime(2016, 12, 12)}
+    assert format_json(data) == '{\n    "Key": "2016-12-12T00:00:00"\n}'


### PR DESCRIPTION
Implements an Info Select interaction that will show the full JSON body of whatever option you're currently selecting in a similar fashion to the docs pane. I held off on adding this because I was unsure about how to safely render the responses as JSON because the `json.dump` method couldn't handle `datetime` objects. It seems the CLI also had this issue and implemented a `json_encoder` util method to handle it. I've refactored the wizards to use this in all places where something is being rendered as JSON.

@JordonPhillips @kyleknap @jamesls 

<img width="723" alt="screen shot 2016-07-27 at 17 08 14" src="https://cloud.githubusercontent.com/assets/1935727/17683822/27591834-630b-11e6-94e0-2c71c616f241.png">