### PR TITLE
Delegation

### DIFF
--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -149,11 +149,12 @@ class ExitHandler(object):
 
 
 class WizardHandler(object):
-    def __init__(self, output=sys.stdout, err=sys.stderr,
-                 loader=WizardLoader()):
+    def __init__(self, output=sys.stdout, err=sys.stderr, loader=None):
         self._output = output
         self._err = err
         self._wizard_loader = loader
+        if self._wizard_loader is None:
+            self._wizard_loader = WizardLoader()
 
     def run(self, command, application):
         """Run the specified wizard.

--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -51,7 +51,7 @@ class WizardLoader(object):
     """
 
     def __init__(self, session=None, interaction_loader=None,
-                 error_handler=None, delegation_loader=None):
+                 error_handler=None):
         """Initialize a wizard factory.
 
         :type session: :class:`botocore.session.Session`
@@ -71,10 +71,6 @@ class WizardLoader(object):
         self._interaction_loader = interaction_loader
         if interaction_loader is None:
             self._interaction_loader = InteractionLoader()
-        if delegation_loader is None:
-            self._delegation_loader = self
-        else:
-            self._delegation_loader = delegation_loader
         self._error_handler = error_handler
         if error_handler is None:
             self._error_handler = stage_error_handler
@@ -126,8 +122,7 @@ class WizardLoader(object):
         }
         creator = self._cached_creator
         interaction = self._interaction_loader
-        delegation = self._delegation_loader
-        return Stage(env, creator, interaction, delegation, **stage_attrs)
+        return Stage(env, creator, interaction, self, **stage_attrs)
 
     def _load_stages(self, stages, env):
         return [self._load_stage(stage, env) for stage in stages]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -154,10 +154,11 @@ def test_exit_dot_command_exits_shell():
     assert mock_prompter.run.call_count == 1
 
 
-def test_wizard_can_load_and_execute():
+def test_wizard_can_load_and_execute(errstream):
     # Proper dot command syntax should load and run a wizard
     mock_loader = mock.Mock()
     mock_wizard = mock_loader.load_wizard.return_value
+    mock_wizard.execute.return_value = {}
     handler = app.WizardHandler(err=errstream, loader=mock_loader)
     handler.run(['.wizard', 'wizname'], None)
 

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -200,20 +200,20 @@ def test_basic_full_execution(wizard_spec, loader):
 def test_basic_full_execution_error(wizard_spec):
     # Test that the wizard can handle exceptions in stage execution
     session = mock.Mock()
-    error_handler = mock.Mock()
-    error_handler.return_value = ('TestStage', 0)
+    error_handler = mock.Mock(side_effect=[('TestStage', 0), None])
     loader = WizardLoader(session, error_handler=error_handler)
     wizard_spec['Stages'][0]['NextStage'] = \
         {'Type': 'Name', 'Name': 'StageTwo'}
     wizard_spec['Stages'][0]['Resolution']['Path'] = '[0].Stage'
     stage_three = {'Name': 'StageThree', 'Prompt': 'Text'}
     wizard = loader.create_wizard(wizard_spec)
-    # force an exception once, let it recover, re-run
-    error = WizardException()
-    wizard.stages['StageTwo'].execute = mock.Mock(side_effect=[error, {}])
-    wizard.execute()
-    # assert error handler was called
-    assert error_handler.call_count == 1
+    # force two exceptions, recover once then fail to recover
+    errors = [WizardException(), TypeError()]
+    wizard.stages['StageTwo'].execute = mock.Mock(side_effect=errors)
+    with pytest.raises(TypeError):
+        wizard.execute()
+    # assert error handler was called twice
+    assert error_handler.call_count == 2
     assert wizard.stages['StageTwo'].execute.call_count == 2
 
 
@@ -286,6 +286,44 @@ def test_wizard_basic_interaction(wizard_spec):
     create = i_loader.create
     create.assert_called_once_with(inter, 'Prompting')
     create.return_value.execute.assert_called_once_with(data)
+
+
+def test_wizard_basic_delegation(wizard_spec):
+    mock_session = mock.Mock(spec=Session)
+    mock_loader = mock.Mock(spec=WizardLoader)
+    loader = WizardLoader(mock_session, delegation_loader=mock_loader)
+    main_spec = {
+        "StartStage": "One",
+        "Stages": [
+            {
+                "Name": "One",
+                "Prompt": "stage one",
+                "Retrieval": {
+                    "Type": "Wizard",
+                    "Resource": "SubWizard",
+                    "Path": "FromSub"
+                }
+            }
+        ]
+    }
+    wizard = loader.create_wizard(main_spec)
+    sub_spec = {
+        "StartStage": "SubOne",
+        "Stages": [
+            {
+                "Name": "SubOne",
+                "Prompt": "stage one",
+                "Retrieval": {
+                    "Type": "Static",
+                    "Resource": {"FromSub": "Result from sub"}
+                }
+            }
+        ]
+    }
+    mock_loader.load_wizard.return_value = loader.create_wizard(sub_spec)
+    result = wizard.execute()
+    mock_loader.load_wizard.assert_called_once_with('SubWizard')
+    assert result == 'Result from sub'
 
 
 exceptions = [


### PR DESCRIPTION
Implemented Wizard Delegation. Wizard specifications can now specify a Retrieval step to delegate like so:
```
"Retrieval": {
    "Type": "Wizard",
    "Resource": "SubWizardName",
    "Path": "JMESPath.query"
}
```
A stage's resolution is no longer a void operation, and the data that would be stored in the environment is now also returned at the end of the stage. Upon executing the final stage the return value from it is returned as the final result of executing the wizard. 

This PR also has a couple fixes to old unit tests to increase coverage.