### PR TITLE
Drop key from environment params if None

### DIFF
--- a/awsshell/wizard.py
+++ b/awsshell/wizard.py
@@ -1,6 +1,7 @@
 import sys
 import copy
 import json
+import logging
 import jmespath
 
 import botocore.session
@@ -13,6 +14,9 @@ from awsshell.selectmenu import select_prompt
 from awsshell.interaction import InteractionLoader, InteractionException
 
 from prompt_toolkit.shortcuts import confirm
+
+
+LOG = logging.getLogger(__name__)
 
 
 def stage_error_handler(error, stages, confirm=confirm, prompt=select_prompt):
@@ -372,5 +376,10 @@ class Environment(object):
         """
         resolved_dict = {}
         for key in keys:
-            resolved_dict[key] = self.retrieve(keys[key])
+            retrieved = self.retrieve(keys[key])
+            if retrieved is not None:
+                resolved_dict[key] = retrieved
+            else:
+                LOG.debug("Query failed (%s), dropped key: %s", keys[key], key)
+
         return resolved_dict

--- a/tests/unit/test_wizard.py
+++ b/tests/unit/test_wizard.py
@@ -37,6 +37,12 @@ def test_resolve_parameters():
     assert resolved == {'a': 'Nice', 'b': 'v'}
 
 
+def test_resolve_parameters_drops_none(env):
+    keys = {'a': 'bad.query', 'b': 'env_var.epic'}
+    resolved = env.resolve_parameters(keys)
+    assert resolved == {'b': 'nice'}
+
+
 @pytest.fixture
 def loader(wizard_spec):
     session = mock.Mock()


### PR DESCRIPTION
When the environment parameters for a request are being resolved if the query to get the variable returns `None` it will be dropped from the request. This will allow for optional parameters without having to have a request stage for each permutation of parameters.