### PR TITLE
Use specific commit for pytest and bump pytest-cov

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
-pytest==2.8.2
-pytest-cov==2.2.0
+# TODO update this to: pytest==3.0.2 it should include the patch
+-e git://github.com/pytest-dev/pytest.git@9c45d6cd83fdc7d336377526bdfb6fc0123d29c0#egg=pytest
+pytest-cov==2.3.1
 mock==1.3.0
 tox==2.2.1
 configobj==5.0.6


### PR DESCRIPTION
Some changes to the cli exposed a bug in the stdin/out capturing feature of pytest. I've opened an upstream pull request to fix this and it has been merged: https://github.com/pytest-dev/pytest/pull/1866. Until this version releases next week, I'll be setting the pytest version to be a specific commit including the bugfix to get tests passing again.

@jamesls @kyleknap 

