### PR TITLE
Data loader

### DIFF
--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -9,6 +9,8 @@ import subprocess
 import logging
 import sys
 
+import botocore.session
+
 from prompt_toolkit.document import Document
 from prompt_toolkit.shortcuts import create_eventloop
 from prompt_toolkit.buffer import Buffer
@@ -154,7 +156,17 @@ class WizardHandler(object):
         self._err = err
         self._wizard_loader = loader
         if self._wizard_loader is None:
-            self._wizard_loader = WizardLoader()
+            session = self._initalize_session()
+            self._wizard_loader = WizardLoader(session=session)
+
+    def _initalize_session(self):
+        """Get a session and append the data directory to search paths."""
+        session = botocore.session.get_session()
+        data_loader = session.get_component('data_loader')
+        shell_root_dir = os.path.dirname(os.path.abspath(__file__))
+        data_path = os.path.join(shell_root_dir, 'data')
+        data_loader.search_paths.append(data_path)
+        return session
 
     def run(self, command, application):
         """Run the specified wizard.

--- a/awsshell/data/wizards/2016-01-01/apigateway.json
+++ b/awsshell/data/wizards/2016-01-01/apigateway.json
@@ -1,0 +1,101 @@
+{
+  "StartStage": "ApiSourceSwitch",
+  "Stages": [
+    {
+      "Name": "ApiSourceSwitch",
+      "Prompt": "What is the source for the new Api?",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Create new Api", "Stage": "CreateApi"},
+          { "Option": "Generate new Api from swagger spec file", "Stage": "NewSwaggerApi"}
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": {
+        "Path": "Stage",
+        "Key": "CreationType"
+      },
+      "NextStage": { "Type": "Variable", "Name": "CreationType" }
+    },
+    {
+      "Name": "NewSwaggerApi",
+      "Prompt": "Enter the path to the JSON swagger spec file",
+      "Interaction": { "ScreenType": "FilePrompt" },
+      "Resolution": { "Key": "SwaggerBlob" },
+      "NextStage": { "Type": "Name", "Name": "ImportApiRequest" }
+    },
+    {
+      "Name": "ImportApiRequest",
+      "Prompt": "Importing Api from swagger spec...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "apigateway",
+          "Operation": "ImportRestApi",
+          "Parameters": { "failOnWarnings": true },
+          "EnvParameters": { "body": "SwaggerBlob" }
+        }
+      }
+    },
+    {
+      "Name": "CreateApi",
+      "Prompt": "Api Name and Description",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": { "name": "", "description": "" }
+      },
+      "Interaction": { "ScreenType": "SimplePrompt" },
+      "Resolution": { "Key": "Details" },
+      "NextStage": { "Type": "Name", "Name": "CloneSwitch" }
+    },
+    {
+      "Name": "CloneSwitch",
+      "Prompt": "Create new empty Api or clone from existing?",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Create new Api", "Stage": "CreateApiRequest" },
+          { "Option": "Clone existing Api", "Stage": "GetApiList" }
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "CloneType" },
+      "NextStage": { "Type": "Variable", "Name": "CloneType" }
+    },
+    {
+      "Name": "GetApiList",
+      "Prompt": "Select an Api to clone",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "apigateway",
+          "Operation": "GetRestApis"
+        },
+        "Path": "items"
+      },
+      "Interaction": { "ScreenType": "InfoSelect", "Path": "[].name" },
+      "Resolution": { "Path": "id", "Key": "ApiId" },
+      "NextStage": { "Type": "Name", "Name": "CreateApiRequest" }
+    },
+    {
+      "Name": "CreateApiRequest",
+      "Prompt": "Creating new Api...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "apigateway",
+          "Operation": "CreateRestApi",
+          "EnvParameters": {
+              "cloneFrom": "ApiId",
+              "name": "Details.name",
+              "description": "Details.description"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/create-instance-profile.json
+++ b/awsshell/data/wizards/2016-01-01/create-instance-profile.json
@@ -1,0 +1,95 @@
+{
+  "StartStage": "NamePrompt",
+  "Stages": [
+    {
+      "Name": "NamePrompt",
+      "Prompt": "Enter the Instance Profile name",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": {"Name": ""}
+      },
+
+      "Interaction": { "ScreenType": "SimplePrompt" },
+      "Resolution": { "Path": "Name", "Key": "ProfileName" },
+      "NextStage": { "Type": "Name", "Name": "CreateProfile" }
+    },
+    {
+      "Name": "CreateProfile",
+      "Prompt": "Creating Profile...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "iam",
+          "Operation": "CreateInstanceProfile",
+          "EnvParameters": {
+              "InstanceProfileName": "ProfileName"
+          }
+        },
+        "Path": "InstanceProfile"
+      },
+      "Resolution": { "Key": "Profile" },
+      "NextStage": { "Type": "Name", "Name": "AddRoleSwitch" }
+    },
+    {
+      "Name": "AddRoleSwitch",
+      "Prompt": "Add a role to this profile?",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Yes", "Stage": "SelectRole"},
+          { "Option": "No", "Stage": "GetRole"}
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "RoleSwitch" },
+      "NextStage": { "Type": "Variable", "Name": "RoleSwitch" }
+    },
+    {
+      "Name": "SelectRole",
+      "Prompt": "Select Role to add:",
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "iam",
+          "Operation": "ListRoles"
+        },
+        "Path": "Roles[].RoleName"
+      },
+      "Interaction": { "ScreenType": "SimpleSelect" },
+      "Resolution": { "Key": "RoleName" },
+      "NextStage": { "Type": "Name", "Name": "AddRole" }
+    },
+    {
+      "Name": "AddRole",
+      "Prompt": "Adding role...",
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "iam",
+          "Operation": "AddRoleToInstanceProfile",
+          "EnvParameters": {
+            "RoleName": "RoleName",
+            "InstanceProfileName": "Profile.InstanceProfileName"
+          }
+        }
+      },
+      "NextStage": { "Type": "Name", "Name": "GetRole" }
+    },
+    {
+      "Name": "GetRole",
+      "Prompt": "Getting role...",
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "iam",
+          "Operation": "GetInstanceProfile",
+          "EnvParameters": {
+            "InstanceProfileName": "Profile.InstanceProfileName"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/create-security-group.json
+++ b/awsshell/data/wizards/2016-01-01/create-security-group.json
@@ -1,0 +1,74 @@
+{
+  "StartStage": "GroupDetails",
+  "Stages": [
+    {
+      "Name": "GroupDetails",
+      "Prompt": "Please enter the details for this group: ",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": {"Name": "", "Description": ""}
+      },
+
+      "Interaction": { "ScreenType": "SimplePrompt" },
+      "Resolution": { "Key": "Details" },
+      "NextStage": { "Type": "Name", "Name": "SelectVPCSwitch" }
+    },
+    {
+      "Name": "SelectVPCSwitch",
+      "Prompt": "Would you like to specify a VPC? ",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Use Default", "Stage": "CreateGroupRequest" },
+          { "Option": "Select a VPC", "Stage": "GetVPC" }
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "VPCSwitch" },
+      "NextStage": { "Type": "Variable", "Name": "VPCSwitch" }
+    },
+    {
+      "Name": "GetVPC",
+      "Prompt": "Getting VPC to use...",
+
+      "Retrieval": { "Type": "Wizard", "Resource": "get-vpc" },
+      "Resolution": { "Path": "VpcId", "Key": "VpcId" },
+      "NextStage": { "Type": "Name", "Name": "CreateGroupRequest" }
+    },
+    {
+      "Name": "CreateGroupRequest",
+      "Prompt": "Creating Security Group...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "CreateSecurityGroup",
+          "Parameters": { "DryRun": false },
+          "EnvParameters": {
+              "VpcId": "VpcId",
+              "GroupName": "Details.Name",
+              "Description": "Details.Description"
+          }
+        }
+      },
+      "Resolution": { "Path": "GroupId", "Key": "GroupId" },
+      "NextStage": { "Type": "Name", "Name": "GetGroup" }
+    },
+    {
+      "Name": "GetGroup",
+      "Prompt": "Getting Security Group...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "DescribeSecurityGroups",
+          "EnvParameters": { "GroupIds": "GroupId | [@]" }
+        }
+      },
+      "Resolution": { "Path": "SecurityGroups[0]", "Key": "Group" }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/create-subnet.json
+++ b/awsshell/data/wizards/2016-01-01/create-subnet.json
@@ -1,0 +1,73 @@
+{
+  "StartStage": "CIDRPrompt",
+  "Stages": [
+    {
+      "Name": "CIDRPrompt",
+      "Prompt": "Enter subnet IP address block (e.g., 10.0.0.0/24)",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": {"CIDR": ""}
+      },
+
+      "Interaction": { "ScreenType": "SimplePrompt" },
+      "Resolution": { "Path": "CIDR", "Key": "CIDR" },
+      "NextStage": { "Type": "Name", "Name": "ZoneSwitch" }
+    },
+    {
+      "Name": "ZoneSwitch",
+      "Prompt": "Would you like to specify an availability zone?",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "No Preference", "Stage": "GetVPC"},
+          { "Option": "Select availability zone", "Stage": "SelectZone"}
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "ZoneSwitch" },
+      "NextStage": { "Type": "Variable", "Name": "ZoneSwitch" }
+    },
+    {
+      "Name": "SelectZone",
+      "Prompt": "Select the desired zone: ",
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "DescribeAvailabilityZones"
+        },
+        "Path": "AvailabilityZones"
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].ZoneName" },
+      "Resolution": { "Path": "ZoneName", "Key": "ZoneName" },
+      "NextStage": { "Type": "Name", "Name": "GetVPC" }
+    },
+    {
+      "Name": "GetVPC",
+      "Prompt": "Getting VPC to use...",
+
+      "Retrieval": { "Type": "Wizard", "Resource": "get-vpc" },
+      "Resolution": { "Path": "VpcId", "Key": "VpcId" },
+      "NextStage": { "Type": "Name", "Name": "CreateSubnet" }
+    },
+    {
+      "Name": "CreateSubnet",
+      "Prompt": "Creating Subnet...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "CreateSubnet",
+          "Parameters": { "DryRun": false },
+          "EnvParameters": {
+              "VpcId": "VpcId",
+              "CidrBlock": "CIDR",
+              "AvailabilityZone": "ZoneName"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/create-vpc.json
+++ b/awsshell/data/wizards/2016-01-01/create-vpc.json
@@ -1,0 +1,46 @@
+{
+  "StartStage": "CIDRPrompt",
+  "Stages": [
+    {
+      "Name": "CIDRPrompt",
+      "Prompt": "Enter VPC IP address block (e.g., 10.0.0.0/16)",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": {"CIDR": ""}
+      },
+
+      "Interaction": { "ScreenType": "SimplePrompt" },
+      "Resolution": { "Path": "CIDR", "Key": "CIDR" },
+      "NextStage": { "Type": "Name", "Name": "SelectTenancy" }
+    },
+    {
+      "Name": "SelectTenancy",
+      "Prompt": "Should this VPC use the default tenancy or force dedicated?",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [ "default", "dedicated"]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect" },
+      "Resolution": { "Key": "Tenancy" },
+      "NextStage": { "Type": "Name", "Name": "CreateVPC" }
+    },
+    {
+      "Name": "CreateVPC",
+      "Prompt": "Creating VPC...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "CreateVpc",
+          "Parameters": { "DryRun": false },
+          "EnvParameters": {
+              "CidrBlock": "CIDR",
+              "InstanceTenancy": "Tenancy"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/get-instance-profile.json
+++ b/awsshell/data/wizards/2016-01-01/get-instance-profile.json
@@ -1,0 +1,44 @@
+{
+  "StartStage": "GetProfileSwitch",
+  "Stages": [
+    {
+      "Name": "GetProfileSwitch",
+      "Prompt": "Select a source for the Instance Profile: ",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+            { "Option": "Create new Profile", "Stage": "CreateProfile" },
+            { "Option": "Select existing Profile", "Stage": "SelectProfile" }
+        ]
+      },
+
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "ProfileSource" },
+      "NextStage": { "Type": "Variable", "Name": "ProfileSource" }
+    },
+    {
+      "Name": "CreateProfile",
+      "Prompt": "Delegate to create Profile",
+      "Retrieval": {
+          "Type": "Wizard",
+          "Resource": "create-instance-profile",
+          "Path": "InstanceProfile"
+      }
+    },
+    {
+      "Name": "SelectProfile",
+      "Prompt": "Select a Profile: ",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "iam",
+          "Operation": "ListInstanceProfiles"
+        },
+        "Path": "InstanceProfiles"
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].InstanceProfileName" }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/get-policy.json
+++ b/awsshell/data/wizards/2016-01-01/get-policy.json
@@ -1,0 +1,30 @@
+{
+  "StartStage": "GetPolicySwitch",
+  "Stages": [
+    {
+      "Name": "GetPolicySwitch",
+      "Prompt": "Select a source for the policy: ",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+            { "Option": "Create new policy", "Stage": "CreatePolicy" },
+            { "Option": "Select managed policy", "Stage": "SelectPolicy" }
+        ]
+      },
+
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "PolicySource" },
+      "NextStage": { "Type": "Variable", "Name": "PolicySource" }
+    },
+    {
+      "Name": "CreatePolicy",
+      "Prompt": "Delegate to create policy"
+    },
+    {
+      "Name": "SelectPolicy",
+      "Prompt": "Delegate to select policy",
+      "Retrieval": { "Type": "Wizard", "Resource": "select-policy" }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/get-security-group.json
+++ b/awsshell/data/wizards/2016-01-01/get-security-group.json
@@ -1,0 +1,43 @@
+{
+  "StartStage": "GetGroupSwitch",
+  "Stages": [
+    {
+      "Name": "GetGroupSwitch",
+      "Prompt": "Select a source for the Security Group: ",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+            { "Option": "Create new Security Group", "Stage": "CreateGroup" },
+            { "Option": "Select existing Security Group", "Stage": "SelectGroup" }
+        ]
+      },
+
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "GroupSource" },
+      "NextStage": { "Type": "Variable", "Name": "GroupSource" }
+    },
+    {
+      "Name": "CreateGroup",
+      "Prompt": "Delegate to create Security Group",
+      "Retrieval": {
+          "Type": "Wizard",
+          "Resource": "create-security-group"
+      }
+    },
+    {
+      "Name": "SelectGroup",
+      "Prompt": "Select a Security Group: ",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "DescribeSecurityGroups"
+        },
+        "Path": "SecurityGroups"
+      },
+      "Interaction": { "ScreenType": "InfoSelect", "Path": "[].GroupId" }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/get-subnet.json
+++ b/awsshell/data/wizards/2016-01-01/get-subnet.json
@@ -1,0 +1,44 @@
+{
+  "StartStage": "GetSubnetSwitch",
+  "Stages": [
+    {
+      "Name": "GetSubnetSwitch",
+      "Prompt": "Select a source for the Subnet: ",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+            { "Option": "Create new Subnet", "Stage": "CreateSubnet" },
+            { "Option": "Select existing Subnet", "Stage": "SelectSubnet" }
+        ]
+      },
+
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "SubnetSource" },
+      "NextStage": { "Type": "Variable", "Name": "SubnetSource" }
+    },
+    {
+      "Name": "CreateSubnet",
+      "Prompt": "Delegate to create subnet",
+      "Retrieval": {
+          "Type": "Wizard",
+          "Resource": "create-subnet",
+          "Path": "Subnet"
+      }
+    },
+    {
+      "Name": "SelectSubnet",
+      "Prompt": "Select a Subnet: ",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "DescribeSubnets"
+        },
+        "Path": "Subnets"
+      },
+      "Interaction": { "ScreenType": "InfoSelect", "Path": "[].SubnetId" }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/get-vpc.json
+++ b/awsshell/data/wizards/2016-01-01/get-vpc.json
@@ -1,0 +1,44 @@
+{
+  "StartStage": "GetVPCSwitch",
+  "Stages": [
+    {
+      "Name": "GetVPCSwitch",
+      "Prompt": "Select a source for the VPC: ",
+
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+            { "Option": "Create new VPC", "Stage": "CreateVPC" },
+            { "Option": "Select existing VPC", "Stage": "SelectVPC" }
+        ]
+      },
+
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "VPCSource" },
+      "NextStage": { "Type": "Variable", "Name": "VPCSource" }
+    },
+    {
+      "Name": "CreateVPC",
+      "Prompt": "Delegate to create VPC",
+      "Retrieval": {
+          "Type": "Wizard",
+          "Resource": "create-vpc",
+          "Path": "Vpc"
+      }
+    },
+    {
+      "Name": "SelectVPC",
+      "Prompt": "Select a VPC: ",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "DescribeVpcs"
+        },
+        "Path": "Vpcs"
+      },
+      "Interaction": { "ScreenType": "InfoSelect", "Path": "[].VpcId" }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/launch-instance.json
+++ b/awsshell/data/wizards/2016-01-01/launch-instance.json
@@ -1,0 +1,161 @@
+{
+  "StartStage": "GetAMI",
+  "Stages": [
+    {
+      "Name": "GetAMI",
+      "Prompt": "Getting AMI to use...",
+
+      "Retrieval": { "Type": "Wizard", "Resource": "select-ami" },
+      "Resolution": { "Path": "ImageId", "Key": "ImageId" },
+      "NextStage": { "Type": "Name", "Name": "InstanceDetails" }
+    },
+
+    {
+      "Name": "InstanceDetails",
+      "Prompt": "Enter minimum and maximium number of instances",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": { "MinCount": "", "MaxCount": "" }
+      },
+      "Interaction": { "ScreenType": "SimplePrompt" },
+      "Resolution": { "Key": "Details" },
+      "NextStage": { "Type": "Name", "Name": "SelectInstanceType" }
+    },
+
+    {
+      "Name": "SelectInstanceType",
+      "Prompt": "Select Instance Type: ",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": ["t2.nano", "t2.micro", "t2.small", "t2.medium", "t2.large"]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect" },
+      "Resolution": { "Key": "InstanceType" },
+      "NextStage": { "Type": "Name", "Name": "SelectProfileSwitch" }
+    },
+
+    {
+      "Name": "SelectProfileSwitch",
+      "Prompt": "Would you like to specify an IAM Instance Profile? ",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Do not use profile", "Stage": "SelectSubnetSwitch"},
+          { "Option": "Select a profile", "Stage": "GetInstanceProfile"}
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "ProfileSwitch" },
+      "NextStage": { "Type": "Variable", "Name": "ProfileSwitch" }
+    },
+    {
+      "Name": "GetInstanceProfile",
+      "Prompt": "Getting Instance Profile to use...",
+
+      "Retrieval": { "Type": "Wizard", "Resource": "get-instance-profile" },
+      "Resolution": { "Key": "Profile" },
+      "NextStage": { "Type": "Name", "Name": "SelectSubnetSwitch" }
+    },
+
+    {
+      "Name": "SelectSubnetSwitch",
+      "Prompt": "Would you like to specify a Subnet? ",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Use Default", "Stage": "SecurityGroupSwitch"},
+          { "Option": "Select a Subnet", "Stage": "GetSubnet"}
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "SubnetSwitch" },
+      "NextStage": { "Type": "Variable", "Name": "SubnetSwitch" }
+    },
+    {
+      "Name": "GetSubnet",
+      "Prompt": "Getting Subnet to use...",
+
+      "Retrieval": { "Type": "Wizard", "Resource": "get-subnet" },
+      "Resolution": { "Path": "SubnetId", "Key": "SubnetId" },
+      "NextStage": { "Type": "Name", "Name": "SecurityGroupSwitch" }
+    },
+
+    {
+      "Name": "SecurityGroupSwitch",
+      "Prompt": "Would you like to specify a Security Group? ",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Use Default", "Stage": "KeySwitch"},
+          { "Option": "Select a Security Group", "Stage": "GetSecurityGroup"}
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "GroupSwitch" },
+      "NextStage": { "Type": "Variable", "Name": "GroupSwitch" }
+    },
+    {
+      "Name": "GetSecurityGroup",
+      "Prompt": "Getting Security Group to use...",
+
+      "Retrieval": { "Type": "Wizard", "Resource": "get-security-group" },
+      "Resolution": { "Path": "GroupId", "Key": "GroupId" },
+      "NextStage": { "Type": "Name", "Name": "KeySwitch" }
+    },
+
+    {
+      "Name": "KeySwitch",
+      "Prompt": "Would you like to attach a Key Pair?",
+      "Retrieval": {
+        "Type": "Static",
+        "Resource": [
+          { "Option": "Do not attach", "Stage": "LaunchInstance"},
+          { "Option": "Select a Key Pair", "Stage": "GetKeyPair"}
+        ]
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].Option" },
+      "Resolution": { "Path": "Stage", "Key": "GroupSwitch" },
+      "NextStage": { "Type": "Variable", "Name": "GroupSwitch" }
+    },
+    {
+      "Name": "GetKeyPair",
+      "Prompt": "Select Key Pair to use: ",
+
+      "Retrieval": {
+          "Type": "Request",
+          "Resource": {
+            "Service": "ec2",
+            "Operation": "DescribeKeyPairs"
+          },
+          "Path": "KeyPairs"
+      },
+      "Interaction": { "ScreenType": "SimpleSelect", "Path": "[].KeyName" },
+      "Resolution": { "Path": "KeyName", "Key": "KeyName" },
+      "NextStage": { "Type": "Name", "Name": "LaunchInstance" }
+    },
+
+    {
+      "Name": "LaunchInstance",
+      "Prompt": "Launching instance...",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "RunInstances",
+          "Parameters": { "DryRun": true },
+          "EnvParameters": {
+              "ImageId": "ImageId",
+              "SubnetId": "SubnetId",
+              "InstanceType": "InstanceType",
+              "MinCount": "Details.MinCount",
+              "MaxCount": "Details.MaxCount",
+              "IamInstanceProfile": "Profile | {Name: @.InstanceProfileName}",
+              "SecurityGroupIds": "GroupId | [@]",
+              "KeyName": "KeyName"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/select-ami.json
+++ b/awsshell/data/wizards/2016-01-01/select-ami.json
@@ -1,0 +1,20 @@
+{
+  "StartStage": "GetAmiList",
+  "Stages": [
+    {
+      "Name": "GetAmiList",
+      "Prompt": "Select an AMI: ",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "ec2",
+          "Operation": "DescribeImages",
+          "Parameters": { "Owners": ["self"] }
+        },
+        "Path": "Images"
+      },
+      "Interaction": { "ScreenType": "FuzzySelect", "Path": "[].Name" }
+    }
+  ]
+}

--- a/awsshell/data/wizards/2016-01-01/select-policy.json
+++ b/awsshell/data/wizards/2016-01-01/select-policy.json
@@ -1,0 +1,19 @@
+{
+  "StartStage": "GetPolicyList",
+  "Stages": [
+    {
+      "Name": "GetPolicyList",
+      "Prompt": "Select a policy: ",
+
+      "Retrieval": {
+        "Type": "Request",
+        "Resource": {
+          "Service": "iam",
+          "Operation": "ListPolicies"
+        },
+        "Path": "Policies"
+      },
+      "Interaction": { "ScreenType": "FuzzySelect", "Path": "[].PolicyName" }
+    }
+  ]
+}


### PR DESCRIPTION
This is to get the wizards I've created checked in somewhere and begin the conversation of how wizard models should be integrated with the shell. From previous discussion it seems that each service should have a `wizards-1.json` file that has a key corresponding to each of these wizards. With this approach the wizard handler command would likely change from `.wizard <name>` to `.wizard <service> <name>`. This would also likely impact the specification for wizard delegation in a similar manner in that the service would also need to be specified. Perhaps rather than the resource being the wizard name directly it would look more like:
```
"Resource": {
    "Service": "ec2",
    "Name": "WizardName"
}
```