### PR TITLE
Set pytest back to proper version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
-# TODO update this to: pytest==3.0.2 it should include the patch
--e git://github.com/pytest-dev/pytest.git@9c45d6cd83fdc7d336377526bdfb6fc0123d29c0#egg=pytest
+pytest==3.0.2
 pytest-cov==2.3.1
 mock==1.3.0
 tox==2.2.1


### PR DESCRIPTION
Pytest was set to track a specific commit for an upstream bugfix that has now been released in a proper patch version. I've set the version back to this.

@kyleknap @jamesls 