### PR TITLE
Update language support tests and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=py36
 sudo: false
 install:
   - travis_retry pip install tox

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py26,py27,py33,py34,py35,py36
 
 [testenv]
 commands = py.test


### PR DESCRIPTION
Adds python 3.6 the tox configuration and adds python 3.5 & 3.6 to
the language classifiers and travis configuration.

Resolves #164

cc @kyleknap @jamesls @dstufft @stealthycoin