### PR TITLE
Upgrade pinned pylint version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 doc8==0.6.0
 flake8==2.5.0
 pep257==0.7.0
-pylint==1.5.0
+pylint==1.7.2
 -rrequirements-test.txt


### PR DESCRIPTION
Travis builds recently started failing due to false positives in pylint (E1102). Despite having our pylint version pinned this issue emerged without any configuration change on our end. I was able to reproduce this failure locally by creating a new virtualenv and following the travis build. Updating the pinned pylint version seems to fix this issue but I'm at a total loss as to how it began failing in the first place.