### PR TITLE
Disable mouse support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,9 @@ Inline Documentation
 The aws-shell will automatically pull up documentation as you type commands.
 It will show inline documentation for CLI options.  There is also a separate
 documentation panel that will show documentation for the current command or
-option you are typing. Pressing F9 or clicking this panel will focus it
-allowing the use of your keybindings or scroll wheel to navigate the docs.
+option you are typing. Pressing F9 will toggle focus to the documentation panel
+allowing you to navigate it using your selected keybindings.
+
 
 .. image:: https://cloud.githubusercontent.com/assets/368057/11823320/36ae9b04-a328-11e5-9661-81abfc0afe5a.png
 

--- a/awsshell/app.py
+++ b/awsshell/app.py
@@ -433,7 +433,7 @@ class AWSShell(object):
         return Application(
             editing_mode=editing_mode,
             layout=self.create_layout(display_completions_in_columns, toolbar),
-            mouse_support=True,
+            mouse_support=False,
             style=style_factory.style,
             buffers=buffers,
             buffer=self.create_buffer(completer, history),


### PR DESCRIPTION
Enabling mouse support removes many standard terminal functionalities such as highlighting text to copy paste and scrolling through the prompt history. For now, the trade off in gained vs lost functionality is too great.