### PR TITLE
Fix "TypeError: generate_shorthand_example() got an unexpected keywor…

### DIFF
--- a/awsshell/makeindex.py
+++ b/awsshell/makeindex.py
@@ -42,7 +42,7 @@ def index_command(index_dict, help_command):
             service_name, op_name = help_command.event_class.rsplit('.', 1)
             example = SHORTHAND_DOC.generate_shorthand_example(
                 cli_argument=arg_obj,
-                service_name=service_name,
+                service_id=service_name,
                 operation_name=op_name,
             )
             metadata['example'] = example


### PR DESCRIPTION
…d argument 'servcice_name'

Fix initialization issue with Python 3.6 and AWS CLI 1.16.11 that prevent aws-shell to start