### PR TITLE
Add ECS autocomplete defenition

### DIFF
--- a/awsshell/data/ecs/2014-11-13/completions-1.json
+++ b/awsshell/data/ecs/2014-11-13/completions-1.json
@@ -1,0 +1,132 @@
+{
+  "operations": {
+    "ListServices": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "CreateService": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "DeleteAttributes": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "DeleteCluster": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "DeleteService": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "DeregisterContainerInstance": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "DescribeContainerInstances": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "DescribeServices": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "DescribeTasks": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "ListAttributes": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "ListContainerInstances": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "ListTasks": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "PutAttributes": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "RegisterContainerInstance": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "RunTask": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "StartTask": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "StopTask": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "UpdateContainerAgent": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "UpdateContainerInstancesState": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    },
+    "UpdateService": {
+      "cluster": {
+        "resourceName": "Cluster",
+        "resourceIdentifier": "Arn"
+      }
+    }
+  },
+  "resources": {
+    "Cluster": {
+      "operation": "ListClusters",
+      "resourceIdentifier": {
+        "Arn": "clusterArns[]"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added ECS command options autocomplete definitions. Only --cluster is supported for now

Adding support for --service autocomplete is less trivial as it needs the value of --cluster. Can anyone offer advice about to implement it in the current autocomplete definitions architecture?