### PR TITLE
Added support to be run via Repl.it

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python /home/runner/scripts/ci/install ; python /home/runner/awsshell/__init__.py"

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ aws-shell - The interactive productivity booster for the AWS CLI
 
 .. image:: https://aws-developer-blog-media.s3-us-west-2.amazonaws.com/cli/Super-Charge-Your-AWS-Command-Line-Experience-with-aws-shell/aws-shell-final.gif
 
+.. image:: https://repl.it/badge/github/awslabs/aws-shell
+    :target: https://repl.it/github/awslabs/aws-shell
 
 Installation
 ============


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it. This means that users will be able to use/test aws-shell directly in the browser. It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/aws-shell-2).