### PR TITLE
Update to support the latest aws-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,10 @@ language: python
 
 matrix:
     include:
-        - python: 2.6
-          env: TEST_TYPE=test
         - python: 2.7
           env: TEST_TYPE=test
         - python: 2.7
           env: TEST_TYPE=check
-        - python: 3.3
-          env: TEST_TYPE=test
         - python: 3.4
           env: TEST_TYPE=test
         - python: 3.5

--- a/awsshell/makeindex.py
+++ b/awsshell/makeindex.py
@@ -5,9 +5,12 @@ import json
 
 from six import BytesIO
 from docutils.core import publish_string
-from botocore.docs.bcdoc import textwriter
 import awscli.clidriver
 from awscli.argprocess import ParamShorthandDocGen
+try:
+    from botocore.docs.bcdoc import textwriter
+except ImportError:
+    from awscli.bcdoc import textwriter
 
 from awsshell import determine_doc_index_filename
 from awsshell.utils import remove_html


### PR DESCRIPTION
Updates documentation related import to support the latest AWS CLI version and adjusts the required cli/sdk versions accordingly.

Fixes #247 

This also removes 2.6 and 3.3 from the Travis matrix as those versions have been EOL for a long time and no longer work on Travis:

```
$ curl -sSf --retry 5 -o python-2.6.tar.bz2 ${archive_url}

curl: (22) The requested URL returned error: 404 Not Found

Unable to download 2.6 archive. The archive may not exist. Please consider a different version.
```